### PR TITLE
Adding configuration support for custom user agents

### DIFF
--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -378,13 +378,13 @@ public struct WebLoadError : Error, CustomStringConvertible {
 public class WebEngineConfiguration : ObservableObject {
     @Published public var javaScriptEnabled: Bool
     @Published public var allowsBackForwardNavigationGestures: Bool
-	@Published public var allowsPullToRefresh: Bool
+    @Published public var allowsPullToRefresh: Bool
     @Published public var allowsInlineMediaPlayback: Bool
     @Published public var dataDetectorsEnabled: Bool
     @Published public var isScrollEnabled: Bool
     @Published public var pageZoom: CGFloat
     @Published public var isOpaque: Bool
-	@Published public var customUserAgent: String
+    @Published public var customUserAgent: String?
     @Published public var userScripts: [WebViewUserScript]
 
     #if SKIP
@@ -394,23 +394,23 @@ public class WebEngineConfiguration : ObservableObject {
 
     public init(javaScriptEnabled: Bool = true,
                 allowsBackForwardNavigationGestures: Bool = true,
-				allowsPullToRefresh: Bool = true,
+                allowsPullToRefresh: Bool = true,
                 allowsInlineMediaPlayback: Bool = true,
                 dataDetectorsEnabled: Bool = true,
                 isScrollEnabled: Bool = true,
                 pageZoom: CGFloat = 1.0,
                 isOpaque: Bool = true,
-				customUserAgent: String = "",
+                customUserAgent: String,
                 userScripts: [WebViewUserScript] = []) {
         self.javaScriptEnabled = javaScriptEnabled
         self.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
-		self.allowsPullToRefresh = allowsPullToRefresh
+        self.allowsPullToRefresh = allowsPullToRefresh
         self.allowsInlineMediaPlayback = allowsInlineMediaPlayback
         self.dataDetectorsEnabled = dataDetectorsEnabled
         self.isScrollEnabled = isScrollEnabled
         self.pageZoom = pageZoom
         self.isOpaque = isOpaque
-		self.customUserAgent = customUserAgent
+        self.customUserAgent = customUserAgent
         self.userScripts = userScripts
     }
 

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -384,6 +384,7 @@ public class WebEngineConfiguration : ObservableObject {
     @Published public var isScrollEnabled: Bool
     @Published public var pageZoom: CGFloat
     @Published public var isOpaque: Bool
+	@Published public var customUserAgent: String
     @Published public var userScripts: [WebViewUserScript]
 
     #if SKIP
@@ -399,6 +400,7 @@ public class WebEngineConfiguration : ObservableObject {
                 isScrollEnabled: Bool = true,
                 pageZoom: CGFloat = 1.0,
                 isOpaque: Bool = true,
+				customUserAgent: String = "",
                 userScripts: [WebViewUserScript] = []) {
         self.javaScriptEnabled = javaScriptEnabled
         self.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
@@ -408,6 +410,7 @@ public class WebEngineConfiguration : ObservableObject {
         self.isScrollEnabled = isScrollEnabled
         self.pageZoom = pageZoom
         self.isOpaque = isOpaque
+		self.customUserAgent = customUserAgent
         self.userScripts = userScripts
     }
 

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -400,7 +400,7 @@ public class WebEngineConfiguration : ObservableObject {
                 isScrollEnabled: Bool = true,
                 pageZoom: CGFloat = 1.0,
                 isOpaque: Bool = true,
-                customUserAgent: String,
+                customUserAgent: String? = nil,
                 userScripts: [WebViewUserScript] = []) {
         self.javaScriptEnabled = javaScriptEnabled
         self.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -206,9 +206,9 @@ extension WebView : ViewRepresentable {
         settings.setSafeBrowsingEnabled(false)
         settings.setAllowContentAccess(true)
         settings.setAllowFileAccess(true)
-		if (config.customUserAgent != "" ) {
-			settings.setUserAgentString(config.customUserAgent)
-		}
+        if (config.customUserAgent != nil ) {
+            settings.setUserAgentString(config.customUserAgent)
+        }
         webEngine.webView.setBackgroundColor(0x000000) // prevents screen flashing: https://issuetracker.google.com/issues/314821744
 
         //settings.setAlgorithmicDarkeningAllowed(boolean allow)
@@ -275,9 +275,9 @@ extension WebView : ViewRepresentable {
         preferences.allowsContentJavaScript = config.javaScriptEnabled
         preferences.preferredContentMode = .recommended
         // preferences.isLockdownModeEnabled = false // The 'com.apple.developer.web-browser' restricted entitlement is required to disable lockdown mode
-		if (config.customUserAgent != "" ) {
-			webEngine.webView.customUserAgent = config.customUserAgent
-		}
+        if (config.customUserAgent != "" ) {
+            webEngine.webView.customUserAgent = config.customUserAgent
+        }
         #endif
 
         return webEngine
@@ -363,12 +363,12 @@ extension WebView : ViewRepresentable {
         webView.allowsBackForwardNavigationGestures = true
         webView.allowsLinkPreview = true
 
-		if config.allowsPullToRefresh == true {
-			// add a pull-to-refresh control to the page
+        if config.allowsPullToRefresh == true {
+            // add a pull-to-refresh control to the page
 
-			webView.scrollView.refreshControl = UIRefreshControl()
-			webView.scrollView.refreshControl?.addTarget(context.coordinator, action: #selector(Coordinator.handleRefreshControl), for: .valueChanged)
-		}
+            webView.scrollView.refreshControl = UIRefreshControl()
+            webView.scrollView.refreshControl?.addTarget(context.coordinator, action: #selector(Coordinator.handleRefreshControl), for: .valueChanged)
+        }
 
         webView.publisher(for: \.title)
             .receive(on: DispatchQueue.main)

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -206,6 +206,9 @@ extension WebView : ViewRepresentable {
         settings.setSafeBrowsingEnabled(false)
         settings.setAllowContentAccess(true)
         settings.setAllowFileAccess(true)
+		if (config.customUserAgent != "" ) {
+			settings.setUserAgentString(config.customUserAgent)
+		}
         webEngine.webView.setBackgroundColor(0x000000) // prevents screen flashing: https://issuetracker.google.com/issues/314821744
 
         //settings.setAlgorithmicDarkeningAllowed(boolean allow)
@@ -272,7 +275,9 @@ extension WebView : ViewRepresentable {
         preferences.allowsContentJavaScript = config.javaScriptEnabled
         preferences.preferredContentMode = .recommended
         // preferences.isLockdownModeEnabled = false // The 'com.apple.developer.web-browser' restricted entitlement is required to disable lockdown mode
-
+		if (config.customUserAgent != "" ) {
+			webEngine.webView.customUserAgent = config.customUserAgent
+		}
         #endif
 
         return webEngine


### PR DESCRIPTION
I have added a configuration option for setting a custom user agents for webviews in both iOS and Android. It initializes as an empty string, and only adds the option to the webview if a custom user agent is defined.

Skip Pull Request Checklist:

- [ X ] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [ X ] REQUIRED: I have tested my change locally with `swift test`
- [ X ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ X ] OPTIONAL: I have tested my change on an Android emulator or device

