### PR TITLE
Bump minimum macOS version to 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "skip-web",
     defaultLocalization: "en",
-    platforms: [.iOS(.v17), .macOS(.v13), .tvOS(.v17), .watchOS(.v10), .macCatalyst(.v17)],
+    platforms: [.iOS(.v17), .macOS(.v14), .tvOS(.v17), .watchOS(.v10), .macCatalyst(.v17)],
     products: [
         .library(name: "SkipWeb", targets: ["SkipWeb"]),
     ],


### PR DESCRIPTION
https://github.com/skiptools/skip-web/issues/3

> SkipWeb does bump the minimum iOS requirement to 17 because it uses `@Observable` (which is new in iOS 17).

`@Observable` became available in iOS 17, and macOS 14, but `Package.swift` declared its minimum supported version is iOS 17 and macOS 13, which can't be right.

Bumping the minimum supported version to 14 will ensure that SkipWeb correctly refuses to run on macOS 13.

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

