### PR TITLE
Fix user scripts

### DIFF
--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -186,6 +186,18 @@ import kotlinx.coroutines.launch
         }
     }
     
+    @MainActor
+    public func updateUserScripts() {
+        let userContentController = webView.configuration.userContentController
+        let allScripts = configuration.userScripts
+        if userContentController.userScripts.sorted(by: { $0.source > $1.source }) != allScripts.map({ $0.webKitUserScript }).sorted(by: { $0.source > $1.source }) {
+            userContentController.removeAllUserScripts()
+            for script in allScripts {
+                userContentController.addUserScript(script.webKitUserScript)
+            }
+        }
+    }
+    
     
     #endif
 }

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -628,7 +628,7 @@ public struct WebViewUserScript: Equatable, Hashable {
         && lhs.allowedDomains == rhs.allowedDomains
     }
 
-    public init(source: String, injectionTime: UserScriptInjectionTime, forMainFrameOnly: Bool, world: ContentWorld = .defaultClient, allowedDomains: Set<String> = Set()) {
+    public init(source: String, injectionTime: UserScriptInjectionTime, forMainFrameOnly: Bool, world: ContentWorld = .page, allowedDomains: Set<String> = Set()) {
         self.source = source
         self.webKitUserScript = UserScript(source: source, injectionTime: injectionTime, forMainFrameOnly: forMainFrameOnly, in: world)
         self.allowedDomains = allowedDomains

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -275,6 +275,14 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     override func onPageFinished(view: PlatformWebView, url: String) {
         logger.log("onPageFinished: \(url)")
         super.onPageFinished(view, url)
+        for userScript in config.userScripts {
+            if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
+                let source = userScript.webKitUserScript.source
+                view.evaluateJavascript(source) { _ in
+                    logger.debug("Executed user script \(source)")
+                }
+            }
+        }
     }
 
     /// Notify the host application that a page has started loading.
@@ -294,6 +302,14 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
                 })
             });
         """) { _ in logger.debug("Added webkit.messageHandlers") }
+        }
+        for userScript in config.userScripts {
+            if userScript.webKitUserScript.injectionTime == .atDocumentStart {
+                let source = userScript.webKitUserScript.source
+                view.evaluateJavascript(source) { _ in
+                    logger.debug("Executed user script \(source)")
+                }
+            }
         }
         super.onPageStarted(view, url, favicon)
     }


### PR DESCRIPTION
In the first commit, I fixed https://github.com/skiptools/skip-web/issues/14 by changing the default `ContentWorld` to `.page`.

In the second commit, I refactored the user script code to move it into the web engine, so it can be tested by `testWebEngine`. The test passes.

In the third commit, I added support for Android.

In this PR and in #11, I removed the two "system" user scripts.

1. `swiftUIWebViewLocationChanged` was designed to swizzle `history.pushState`, `history.replaceState`, and observe `popstate`. The user script called swiftUIWebViewLocationChanged, but the implementation just set `needsHistoryRefresh`, a variable which was written, but never read.
2. `swiftUIWebViewImageUpdated` added a `MutationObserver` to the document, watching for changes to the `og:image`. When it detected changes, it posted those back, and the web view would update `pageImageURL` on the `WebViewState`. `MutationObserver` has a significant performance penalty; I think this feature should be disabled by default. (For my own use case, it's not useful at all.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

