### PR TITLE
Let users evaluate JS with their own navigator

### DIFF
--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -162,6 +162,11 @@ public class WebViewNavigator {
         logger.info("goForward webView: \(self.webEngine?.description ?? "NONE")")
         webEngine?.goForward()
     }
+    
+    @MainActor public func evaluateJavaScript(_ js: String) async throws -> String? {
+        logger.info("evaluateJavaScript webView: \(self.webEngine?.description ?? "NONE")")
+        return try await webEngine?.evaluate(js: js)
+    }
 }
 
 


### PR DESCRIPTION
Combined with #19 and #20, users could write code like this:

```swift
struct ContentView: View {
    let navigator = WebViewNavigator(initialURL: URL(string: "https://www.example.com")!)
    var body: some View {
        WebView(
            configuration: WebEngineConfiguration(),
            navigator: navigator,
            onNavigationFinished: {
                Task {
                    do {
                        _ = try await navigator.evaluateJavaScript("console.log('hello');")
                        let x = try await navigator.evaluateJavaScript("document.title")
                        print("x \(String(describing: x))")
                    } catch {
                        print(error)
                    }
                }
                
            }
        )
    }
}
```

This PR would answer my question from https://github.com/orgs/skiptools/discussions/426

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

