### PR TITLE
JSON.stringify Android postMessage argument

### DIFF
--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -321,7 +321,7 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
             if (!window.webkit) window.webkit = {};
             webkit.messageHandlers = new Proxy({}, {
                 get: (target, messageHandlerName, receiver) => ({
-                    postMessage: (body) => skipWebAndroidMessageHandler.postMessage(String(messageHandlerName), String(body))
+                    postMessage: (body) => skipWebAndroidMessageHandler.postMessage(String(messageHandlerName), JSON.stringify(body))
                 })
             });
         """) { _ in logger.debug("Added webkit.messageHandlers") }

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -191,12 +191,13 @@ typealias ViewRepresentable = NSViewRepresentable
 public struct MessageHandlerRouter {
     let webEngine: WebEngine
     // SKIP INSERT: @android.webkit.JavascriptInterface
-    public func postMessage(_ name: String, body: String) {
+    public func postMessage(_ name: String, json: String) {
         guard let messageHandler = webEngine.configuration.messageHandlers[name] else {
             logger.error("no messageHandler for \(name)")
             return
         }
         let frameInfo = FrameInfo(isMainFrame: true, request: URLRequest(url: URL(string: "about:blank")!), securityOrigin: SecurityOrigin(), webView: webEngine.webView)
+        let body = try JSONSerialization.jsonObject(with: json.data(using: .utf8)!, options: [])
         let message = WebViewMessage(frameInfo: frameInfo, uuid: UUID(), name: name, body: body)
         Task {
             await messageHandler(message)


### PR DESCRIPTION
This allows passing any JSON-serializable object to the postMessage method, not just strings.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

