### PR TITLE
Add SkipWebUIDelegate popup handling API and docs (#1)

### DIFF
--- a/SkipWebUIDelegate.md
+++ b/SkipWebUIDelegate.md
@@ -1,0 +1,132 @@
+# SkipWebUIDelegate
+
+`SkipWebUIDelegate` is the popup/window-creation delegate API for `SkipWeb`.
+Assign it through `WebEngineConfiguration.uiDelegate` when you need to control child-window behavior (`target=_blank`, `window.open`, multi-window flows).
+
+## Protocol
+
+```swift
+public protocol SkipWebUIDelegate: AnyObject {
+    func webView(
+        _ webView: WebView,
+        createWebViewWith request: WebWindowRequest,
+        platformContext: PlatformCreateWindowContext
+    ) -> WebEngine?
+
+    func webViewDidClose(_ webView: WebView, child: WebEngine)
+}
+```
+
+## Behavior
+
+- `webView(_:createWebViewWith:platformContext:)`
+  - Return `nil` to deny popup creation.
+  - Return a child `WebEngine` to allow popup creation.
+  - `request.targetURL` may be `nil` on Android at creation time.
+- `webViewDidClose(_:child:)`
+  - Called when a previously-created child window is closed via javascript (`window.close()`).
+
+## Platform Mapping
+
+- iOS
+  - create callback is wired from `WKUIDelegate.webView(_:createWebViewWith:for:windowFeatures:)`
+  - close callback is wired from `WKUIDelegate.webViewDidClose(_:)`
+- Android
+  - create callback is wired from `WebChromeClient.onCreateWindow`
+  - close callback is wired from `WebChromeClient.onCloseWindow`
+
+## Usage Example
+
+The example below is inspired by the sandbox experiment and demonstrates:
+- a direct `SkipWebUIDelegate` implementation
+- allowing popup creation by returning a child engine
+- optional callback hooks for host UI/logging
+- platform-safe child engine construction with `PlatformWebView`, an alias for `WkWebView` (iOS) and `WebView` (Android)
+
+```swift
+import Foundation
+// Need to use @preconcurrency here because Type 'WebEngine' does not conform to the 'Sendable' protocol
+@preconcurrency import SkipWeb
+
+/* SKIP @bridge */
+public final class PopupDelegateProbe: NSObject, SkipWebUIDelegate {
+    // SKIP @nobridge
+    var onCreate: ((WebWindowRequest, WebEngine) -> Void)?
+
+    // SKIP @nobridge
+    var onClose: ((WebView, WebEngine) -> Void)?
+
+    /* SKIP @bridge */
+    public func webView(
+        _ webView: WebView,
+        createWebViewWith request: WebWindowRequest,
+        platformContext: PlatformCreateWindowContext
+    ) -> WebEngine? {
+        let child = Self.makeChildEngine(platformContext: platformContext)
+        onCreate?(request, child)
+        return child
+    }
+
+    /* SKIP @bridge */
+    public func webViewDidClose(_ webView: WebView, child: WebEngine) {
+        onClose?(webView, child)
+    }
+
+    private static func makeChildEngine(platformContext: PlatformCreateWindowContext) -> WebEngine {
+        #if os(Android)
+        return MainActor.assumeIsolated {
+            WebEngine(configuration: WebEngineConfiguration())
+        }
+        #else
+        return MainActor.assumeIsolated {
+            let child = platformContext.makeChildWebEngine()
+            return child
+        }
+        #endif
+    }
+}
+```
+
+Attach the delegate to your configuration:
+
+```swift
+import SwiftUI
+@preconcurrency import SkipWeb
+
+struct PopupHostView: View {
+    private let delegate = PopupDelegateProbe()
+
+    @State internal var navigator = WebViewNavigator()
+    @State internal var state = WebViewState()
+    @State internal var configuration: WebEngineConfiguration
+
+    init() {
+        let config = WebEngineConfiguration(
+            javaScriptEnabled: true,
+            javaScriptCanOpenWindowsAutomatically: true
+        )
+        config.uiDelegate = delegate
+        _configuration = State(initialValue: config)
+    }
+
+    var body: some View {
+        WebView(
+            configuration: configuration,
+            navigator: navigator,
+            url: URL(string: "https://example.com")!,
+            state: $state
+        )
+    }
+}
+```
+
+## Notes
+
+- Keep delegate method signatures exactly aligned with the protocol.
+- Keep the delegate class shape simple and direct.
+- On iOS, WebKit requires the returned child to be initialized with the exact configuration supplied to `WKUIDelegate.createWebViewWith`.
+- If this contract is violated, WebKit can raise `NSInternalInconsistencyException` with: `Returned WKWebView was not created with the given configuration.`
+- For iOS popup creation, return a child created via `platformContext.makeChildWebEngine(...)`.
+- `makeChildWebEngine()` mirrors the parent `WebEngineConfiguration` and inspectability by default. Pass an explicit configuration only when you intentionally want different child behavior.
+- `makeChildWebEngine()` does not automatically copy platform delegate assignments (`WKUIDelegate`, `WKNavigationDelegate`) from the parent web view; assign those explicitly when needed.
+- `PlatformCreateWindowContext` aliases `WebKitCreateWindowParams` on iOS and `AndroidCreateWindowParams` on Android.

--- a/Tests/SkipWebTests/SkipWebTests.swift
+++ b/Tests/SkipWebTests/SkipWebTests.swift
@@ -11,6 +11,8 @@ final class SkipWebTests: XCTestCase {
 
     #if SKIP || os(iOS)
 
+    final class DummyUIDelegate: SkipWebUIDelegate { }
+
     // SKIP INSERT: @get:org.junit.Rule val composeRule = androidx.compose.ui.test.junit4.createComposeRule()
 
     func testSkipWeb() throws {
@@ -21,6 +23,35 @@ final class SkipWebTests: XCTestCase {
         let resourceURL: URL = try XCTUnwrap(Bundle.module.url(forResource: "TestData", withExtension: "json"))
         let testData = try JSONDecoder().decode(TestData.self, from: Data(contentsOf: resourceURL))
         XCTAssertEqual("SkipWeb", testData.testModuleName)
+    }
+
+    func testWindowConfigurationDefaults() {
+        let config = WebEngineConfiguration()
+        XCTAssertFalse(config.javaScriptCanOpenWindowsAutomatically)
+        XCTAssertNil(config.uiDelegate)
+    }
+
+    func testWebWindowRequestCarriesFields() throws {
+        let sourceURL = try XCTUnwrap(URL(string: "https://source.example"))
+        let targetURL = try XCTUnwrap(URL(string: "https://target.example"))
+        let request = WebWindowRequest(
+            sourceURL: sourceURL,
+            targetURL: targetURL,
+            isUserGesture: true,
+            isDialog: false,
+            isMainFrame: true
+        )
+        XCTAssertEqual(request.sourceURL?.absoluteString, sourceURL.absoluteString)
+        XCTAssertEqual(request.targetURL?.absoluteString, targetURL.absoluteString)
+        XCTAssertEqual(request.isUserGesture, true)
+        XCTAssertEqual(request.isDialog, false)
+        XCTAssertEqual(request.isMainFrame, true)
+    }
+
+    func testConfigurationAcceptsUIDelegate() {
+        let config = WebEngineConfiguration()
+        config.uiDelegate = DummyUIDelegate()
+        XCTAssertNotNil(config.uiDelegate)
     }
 
     func testOnWebView() async throws {
@@ -254,4 +285,3 @@ class WebViewActivity : androidx.activity.ComponentActivity {
 
 }
 #endif
-


### PR DESCRIPTION
Added SkipWebUIDelegate as a cross-platform popup/window delegate (WebEngineConfiguration.uiDelegate) to control child-window creation and lifecycle. The delegate exposes:

-webView(_:createWebViewWith:platformContext:) -> WebEngine? to allow/deny popup creation by returning a child engine or nil. platformContext is platform-typed (WebKitCreateWindowParams on iOS, AndroidCreateWindowParams on Android) so apps can use native popup details while keeping one shared API.
-webViewDidClose(_: child: ) to notify when a child window is closed.

Soft-deprecated pageURL (String?) in favor of url (URL?) to more closely mirror the WKWebView

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [ x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x ] REQUIRED: I have tested my change locally with `swift test`
- [ x] OPTIONAL: I have tested my change on an iOS simulator or device
- [ x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code under supervision. Code was reviewed + tested from a sandbox app
-----

