### PR TITLE
Content blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - Mirror content blockers into popup child engines and install them for caller-supplied `WKWebView` instances
   - Recompile changed iOS content-blocker rule files, prune stale cached rule lists, and expose setup errors on `WebEngine`/`WebEngineConfiguration`
   - Add `WebEngineConfiguration.clearContentBlockerCache()` so apps can explicitly remove persisted iOS compiled rule lists
+  - Add shared `whitelistedDomains` content-blocker config that bypasses blocking on matching iOS and Android page domains
   - Make Android redirect detection best-effort for request blocking on runtimes that do not support `WEB_RESOURCE_REQUEST_IS_REDIRECT`
 
 ## 0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
   - Add portable content-blocker configuration with iOS rule-list support and Android request/cosmetic blocker hooks
   - Mirror content blockers into popup child engines and install them for caller-supplied `WKWebView` instances
   - Recompile changed iOS content-blocker rule files, prune stale cached rule lists, and expose setup errors on `WebEngine`/`WebEngineConfiguration`
-  - Add `WebEngineConfiguration.clearContentBlockerCache()` so apps can explicitly remove persisted iOS compiled rule lists
+  - Add `WebEngineConfiguration.iOSClearContentBlockerCache()` so apps can explicitly remove persisted iOS compiled rule lists
   - Add shared `whitelistedDomains` content-blocker config that bypasses blocking on matching iOS and Android page domains
   - Make Android redirect detection best-effort for request blocking on runtimes that do not support `WEB_RESOURCE_REQUEST_IS_REDIRECT`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+  - Add portable content-blocker configuration with iOS rule-list support and Android request/cosmetic blocker hooks
+  - Mirror content blockers into popup child engines and install them for caller-supplied `WKWebView` instances
+  - Recompile changed iOS content-blocker rule files, prune stale cached rule lists, and expose setup errors on `WebEngine`/`WebEngineConfiguration`
+  - Make Android redirect detection best-effort for request blocking on runtimes that do not support `WEB_RESOURCE_REQUEST_IS_REDIRECT`
+
 ## 0.5.1
 
 Released 2024-09-03
@@ -86,5 +93,4 @@ Released 2023-11-22
 ## 0.0.2
 
 Released 2023-11-22
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Add portable content-blocker configuration with iOS rule-list support and Android request/cosmetic blocker hooks
   - Mirror content blockers into popup child engines and install them for caller-supplied `WKWebView` instances
   - Recompile changed iOS content-blocker rule files, prune stale cached rule lists, and expose setup errors on `WebEngine`/`WebEngineConfiguration`
+  - Add `WebEngineConfiguration.clearContentBlockerCache()` so apps can explicitly remove persisted iOS compiled rule lists
   - Make Android redirect detection best-effort for request blocking on runtimes that do not support `WEB_RESOURCE_REQUEST_IS_REDIRECT`
 
 ## 0.5.1
@@ -93,4 +94,3 @@ Released 2023-11-22
 ## 0.0.2
 
 Released 2023-11-22
-

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://source.skip.tools/skip.git", from: "1.8.2"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.50.0")
+        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.51.0")
     ],
     targets: [
         .target(name: "SkipWeb", dependencies: [.product(name: "SkipUI", package: "skip-ui")], resources: [.process("Resources")], plugins: [.plugin(name: "skipstone", package: "skip")]),

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "SkipWeb", targets: ["SkipWeb"]),
     ],
     dependencies: [
-        .package(url: "https://source.skip.tools/skip.git", from: "1.7.4"),
+        .package(url: "https://source.skip.tools/skip.git", revision: "63225faec18c1d34db0caeb4f4b787e4894e845d"),
         .package(url: "https://source.skip.tools/skip-ui.git", from: "1.50.0")
     ],
     targets: [
@@ -19,9 +19,15 @@ let package = Package(
 )
 
 if Context.environment["SKIP_BRIDGE"] ?? "0" != "0" {
-    package.dependencies += [.package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0")]
+    package.dependencies += [
+        .package(url: "https://source.skip.tools/skip-bridge.git", "0.0.0"..<"2.0.0"),
+        .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0")
+    ]
     package.targets.forEach({ target in
-        target.dependencies += [.product(name: "SkipFuseUI", package: "skip-fuse-ui")]
+        target.dependencies += [
+            .product(name: "SkipBridge", package: "skip-bridge"),
+            .product(name: "SkipFuseUI", package: "skip-fuse-ui")
+        ]
     })
     // all library types must be dynamic to support bridging
     package.products = package.products.map({ product in

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "SkipWeb", targets: ["SkipWeb"]),
     ],
     dependencies: [
-        .package(url: "https://source.skip.tools/skip.git", revision: "63225faec18c1d34db0caeb4f4b787e4894e845d"),
+        .package(url: "https://source.skip.tools/skip.git", from: "1.8.2"),
         .package(url: "https://source.skip.tools/skip-ui.git", from: "1.50.0")
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -90,11 +90,14 @@ let config = WebEngineConfiguration(
             "example.com",
             "*.example.org"
         ],
+        popupWhitelistedSourceDomains: [
+            "example.com"
+        ],
         androidMode: .custom(MyAndroidContentBlockingProvider())
     )
 )
 
-_ = await config.prepareContentBlockers()
+_ = await config.iOSPrepareContentBlockers()
 ```
 
 On Android, `AndroidCosmeticRule` can now carry current-frame guards directly:
@@ -113,6 +116,27 @@ Think of it as "return selectors, render CSS once at the edge". `SkipWeb` instal
 
 For Android navigation callbacks, prefer `WebEngineConfiguration.navigationDelegate`.
 `WebEngine.engineDelegate` remains available as a deprecated compatibility escape hatch, but SkipWeb now keeps blocker enforcement on an internal engine-owned `WebViewClient`.
+
+For example, you can use `shouldOverrideURLLoading` to hand `mailto:` links or app deep links to native code before the `WebView` navigates:
+
+```swift
+final class AppNavigationDelegate: SkipWebNavigationDelegate {
+    func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool {
+        if url.scheme == "mailto" {
+            openSystemMailComposer(url)
+            return true
+        }
+        if url.scheme == "myapp" {
+            routeIntoNativeScreen(url)
+            return true
+        }
+        return false
+    }
+}
+
+let config = WebEngineConfiguration()
+config.navigationDelegate = AppNavigationDelegate()
+```
 
 Navigation APIs:
 
@@ -260,6 +284,8 @@ The `createWebViewWith` callback returns a `WebEngine?`:
 
 - Return `nil` to deny child-window creation.
 - Return a child `WebEngine` to allow child-window creation.
+- Without `WebEngineConfiguration.uiDelegate`, `_blank` / `window.open(...)` falls back to platform defaults:
+  on iOS the popup request is denied, while on Android the current `WebView` may navigate instead of opening a child window.
 
 JavaScript popup behavior can be configured with:
 
@@ -597,9 +623,10 @@ Quick summary:
 
 - `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and attached by SkipWeb.
 - `whitelistedDomains` accepts WebKit-style entries such as `example.com` and `*.example.com`, normalizes them, and disables blocking for matching page domains across both platforms.
-- `androidMode: .custom(...)` is the primary Android API; the legacy `androidRequestBlocker` and `androidCosmeticBlocker` shims remain available as deprecated compatibility paths for one release.
-- `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list cache so the next install recompiles from source.
-- `prepareContentBlockers()` lets apps prewarm iOS blocker setup without importing `WebKit`.
+- `popupWhitelistedSourceDomains` is the popup-only override. A bare entry like `example.com` means "this site", so it covers both `example.com` and common subdomains such as `www.example.com`; `*.example.com` remains subdomains-only.
+- `androidMode: .custom(...)` is the Android content-blocking entry point.
+- `WebEngineConfiguration.iOSClearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list cache so the next install recompiles from source.
+- `iOSPrepareContentBlockers()` lets apps prewarm iOS blocker setup without importing `WebKit`.
 - Popup children and caller-supplied `WKWebView` instances inherit the configured blocker setup.
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -637,7 +637,8 @@ Platform behavior:
 
 - On iOS, `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList`s and attached to the web view's `WKUserContentController`.
 - SkipWeb persists compiled iOS rule lists in a cache keyed by source path and file contents, recompiles when a rule file changes, and prunes stale compiled entries when rule files are removed from the configuration.
-- iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` while building the configuration and through `WebEngine.contentBlockerSetupErrors` after engine creation.
+- On iOS, create configured `WKWebViewConfiguration` instances with `await WebEngineConfiguration.makeWebViewConfiguration()`, which compiles and installs any configured rule lists before returning.
+- iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` after `makeWebViewConfiguration()` completes and through `await WebEngine.awaitContentBlockerSetup()` / `WebEngine.contentBlockerSetupErrors` after engine creation.
 - When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
 - Popup children created with `platformContext.makeChildWebEngine(...)` inherit the mirrored content-blocker configuration.
 - On Android, SkipWeb now installs an engine-owned `WebViewClient` so content blocking stays active for `WebView`, popup children, and direct/headless `WebEngine` usage.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ let config = WebEngineConfiguration(
 _ = await config.prepareContentBlockers()
 ```
 
+On Android, `AndroidCosmeticRule` can now carry current-frame guards directly:
+
+```swift
+AndroidCosmeticRule(
+    hiddenSelectors: ["#subframe-ad"],
+    urlFilterPattern: ".*\\/subframe\\.html",
+    ifDomainList: ["127.0.0.1"],
+    frameScope: .allFrames,
+    preferredTiming: .documentStart
+)
+```
+
+Think of it as "return selectors, render CSS once at the edge". `SkipWeb` installs the rule at document start for all frames, then the injected script checks the frame's own URL and host before turning the matching selectors into `display: none !important`. That is what makes subframe cosmetic blocking work on Android without needing a second late injection path.
+
 For Android navigation callbacks, prefer `WebEngineConfiguration.navigationDelegate`.
 `WebEngine.engineDelegate` remains available as a deprecated compatibility escape hatch, but SkipWeb now keeps blocker enforcement on an internal engine-owned `WebViewClient`.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ let config = WebEngineConfiguration(
         iOSRuleListPaths: [
             Bundle.main.path(forResource: "content-blockers", ofType: "json")!
         ],
+        whitelistedDomains: [
+            "example.com",
+            "*.example.org"
+        ],
         androidMode: .custom(MyAndroidContentBlockingProvider())
     )
 )
@@ -571,89 +575,15 @@ Platform behavior:
 
 `SkipWeb` exposes portable content-blocking hooks through `WebEngineConfiguration.contentBlockers`.
 
-Supporting types:
+For a fuller guide with a quick integration example, whitelist behavior, and up-to-date blocker API shapes, see [`SkipWebContentBlockers.md`](./SkipWebContentBlockers.md).
 
-- `WebContentBlockerConfiguration`
-- `AndroidContentBlockingMode`
-- `AndroidContentBlockingProvider`
-- `AndroidBlockableRequest`
-- `AndroidRequestBlockDecision`
-- `AndroidPageContext`
-- `AndroidCosmeticRule`
-- `AndroidCosmeticFrameScope`
-- `AndroidCosmeticInjectionTiming`
-- `AndroidRequestBlocker` (deprecated compatibility shim)
-- `AndroidCosmeticBlocker` (deprecated compatibility shim)
-- `WebContentBlockerError`
+Quick summary:
 
-Example:
-
-```swift
-struct CustomBlockingProvider: AndroidContentBlockingProvider {
-    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
-        if request.url.host?.contains("ads") == true {
-            return .block
-        }
-        return .allow
-    }
-
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-        [
-            AndroidCosmeticRule(
-                hiddenSelectors: [
-                    ".ad-banner"
-                ]
-            ),
-            AndroidCosmeticRule(
-                hiddenSelectors: [
-                    ".ad-slot",
-                    ".tracking-frame"
-                ],
-                urlFilterPattern: ".*\\/ad-frame\\.html",
-                allowedOriginRules: ["https://*.doubleclick.net"],
-                frameScope: .subframesOnly
-            ),
-            AndroidCosmeticRule(
-                css: [
-                    "body.modal-open { overflow: auto !important; }"
-                ],
-                preferredTiming: .pageLifecycle
-            )
-        ]
-    }
-}
-
-let config = WebEngineConfiguration(
-    contentBlockers: WebContentBlockerConfiguration(
-        iOSRuleListPaths: ["/path/to/content-blockers.json"],
-        androidMode: .custom(CustomBlockingProvider())
-    )
-)
-
-try WebEngineConfiguration.clearContentBlockerCache()
-```
-
-`androidRequestBlocker` and `androidCosmeticBlocker` remain available as deprecated compatibility shims for one release, but new integrations should prefer `androidMode`.
-
-Platform behavior:
-
-- On iOS, `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList`s and attached to the web view's `WKUserContentController`.
-- SkipWeb persists compiled iOS rule lists in a cache keyed by source path and file contents, recompiles when a rule file changes, and prunes stale compiled entries when rule files are removed from the configuration.
-- Call `WebEngineConfiguration.clearContentBlockerCache()` to explicitly remove the persisted iOS rule-list cache and force recompilation on the next install. On Android this API is a no-op.
-- On iOS, create configured `WKWebViewConfiguration` instances with `await WebEngineConfiguration.makeWebViewConfiguration()`, which compiles and installs any configured rule lists before returning.
-- iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` after `makeWebViewConfiguration()` completes and through `await WebEngine.awaitContentBlockerSetup()` / `WebEngine.contentBlockerSetupErrors` after engine creation.
-- When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
-- Popup children created with `platformContext.makeChildWebEngine(...)` inherit the mirrored content-blocker configuration.
-- On Android, SkipWeb now installs an engine-owned `WebViewClient` so content blocking stays active for `WebView`, popup children, and direct/headless `WebEngine` usage.
-- On Android, `.custom(...)` receives an `AndroidBlockableRequest` for intercepted resource loads and can return `.allow` or `.block`.
-- `AndroidBlockableRequest.isRedirect` is best-effort on Android and may be `nil` when the device's WebView runtime does not support redirect detection.
-- On Android, `.custom(...)` also returns ordered `AndroidCosmeticRule` values. Each rule can scope CSS to matching frame document URLs with `urlFilterPattern`, scope frame origins with `allowedOriginRules`, control frame scope with `frameScope`, and prefer `.documentStart` or `.pageLifecycle` injection timing.
-- `AndroidCosmeticRule(hiddenSelectors: ...)` is the convenience path for iOS-style cosmetic hiding and expands each selector to `display: none !important;`.
-- `AndroidCosmeticFrameScope` supports `.mainFrameOnly` (the default), `.subframesOnly`, and `.allFrames`. Use `.subframesOnly` when you want CSS to apply only inside iframe/frame documents instead of the top-level page.
-- Subframe-targeted Android cosmetic rules require document-start script injection. If Android cannot install document-start scripts, SkipWeb only falls back main-frame `.documentStart` rules to page-lifecycle injection; `.subframesOnly` and `.allFrames` rules are skipped in that situation.
-- `.pageLifecycle` injection is main-frame-only on Android. If you need to target subframes, keep `preferredTiming` at `.documentStart`.
-- Same-document navigations on Android, such as `history.pushState`, `history.replaceState`, and hash-only URL changes, do not currently refresh URL-scoped cosmetic rules. Treat `urlFilterPattern` matching as navigation-time behavior rather than a live SPA routing hook.
-- Keep using `css:` when you need more than hiding, such as layout repair or `pointer-events` fixes after removing an overlay.
+- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and attached to the web view's `WKUserContentController`.
+- `whitelistedDomains` accepts WebKit-style entries such as `example.com` and `*.example.com`, normalizes them, and disables blocking for matching page domains across both platforms.
+- `androidMode: .custom(...)` is the primary Android API; the legacy `androidRequestBlocker` and `androidCosmeticBlocker` shims remain available as deprecated compatibility paths for one release.
+- `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list cache so the next install recompiles from source.
+- Popup children and caller-supplied `WKWebView` instances inherit the configured blocker setup.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SkipWeb provides two ways to display web content in [Skip Lite](https://skip.dev) apps:
 
-- **[WebView](#webview-customizable-embedded-web-browser)** — A fully customizable embedded browser for app-integrated web content. Supports JavaScript execution, navigation control, scroll delegates, snapshots, and popups. Backed by `WKWebView` on iOS and `android.webkit.WebView` on Android.
+- **[WebView](#webview-customizable-embedded-web-browser)** — A fully customizable embedded browser for app-integrated web content. Supports JavaScript execution, navigation control, scroll delegates, snapshots, popups, and content blockers. Backed by `WKWebView` on iOS and `android.webkit.WebView` on Android.
 
 - **[WebBrowser](#webbrowser-lightweight-in-app-browser)** — A lightweight View modifier that opens a URL in the platform's native in-app browser (`SFSafariViewController` on iOS, Chrome Custom Tabs on Android). Ideal for external links where you want a polished browsing experience with minimal code.
 
@@ -77,6 +77,20 @@ let config = WebEngineConfiguration(
 `WebViewNavigator` can keep a warm `WebEngine` and reuse it across view recreation.
 When the same navigator is rebound to an engine that already has content/history, `initialURL`/`initialHTML` are not reloaded.
 This lets apps preserve page state when navigating away and back with the same navigator instance.
+
+Content blockers are also configured on `WebEngineConfiguration`:
+
+```swift
+let config = WebEngineConfiguration(
+    contentBlockers: WebContentBlockerConfiguration(
+        iOSRuleListPaths: [
+            Bundle.main.path(forResource: "content-blockers", ofType: "json")!
+        ],
+        androidRequestBlocker: MyAndroidRequestBlocker(),
+        androidCosmeticBlocker: MyAndroidCosmeticBlocker()
+    )
+)
+```
 
 Navigation APIs:
 
@@ -255,6 +269,7 @@ SkipWeb validates this contract at popup creation time:
 For iOS parity, return a child created with `platformContext.makeChildWebEngine(...)`.
 By default this mirrors the parent `WebEngineConfiguration` and inspectability on the popup child. Pass an explicit configuration only when you intentionally want the child to diverge.
 This default mirroring is configuration-level. Platform delegate assignments on the returned child (`WKUIDelegate`, `WKNavigationDelegate`) are not automatically copied from the parent, so assign them explicitly if your app depends on that behavior.
+Mirrored popup configuration also carries over `contentBlockers`, so children created with `makeChildWebEngine(...)` inherit the parent's blocker setup.
 On Android, once a child is returned from the delegate, SkipWeb mirrors key parent web settings and inherits the parent `WebProfile` onto the child; if profile inheritance fails, popup creation is denied.
 
 ### Scroll Delegate
@@ -549,6 +564,59 @@ Platform behavior:
 - `removeData(ofTypes:modifiedSince:)` maps to iOS `WKWebsiteDataStore.removeData`.
 - On Android, `removeData` requires `modifiedSince == .distantPast` when `ofTypes` is non-empty; otherwise it throws `WebDataRemovalError.unsupportedModifiedSinceOnAndroid`.
 - Android data removal is bucket-level (cookies/cache/storage), not timestamp-granular, and may clear a broader bucket than an individual requested data type.
+
+## Content Blockers
+
+`SkipWeb` exposes portable content-blocking hooks through `WebEngineConfiguration.contentBlockers`.
+
+Supporting types:
+
+- `WebContentBlockerConfiguration`
+- `AndroidRequestBlocker`
+- `AndroidBlockableRequest`
+- `AndroidCosmeticBlocker`
+- `AndroidCosmeticPayload`
+- `WebContentBlockerError`
+
+Example:
+
+```swift
+struct DomainBlocker: AndroidRequestBlocker {
+    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+        if request.url.host?.contains("ads") == true {
+            return .block
+        }
+        return .allow
+    }
+}
+
+struct CosmeticBlocker: AndroidCosmeticBlocker {
+    func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload? {
+        AndroidCosmeticPayload(css: [
+            ".ad-banner { display: none !important; }"
+        ])
+    }
+}
+
+let config = WebEngineConfiguration(
+    contentBlockers: WebContentBlockerConfiguration(
+        iOSRuleListPaths: ["/path/to/content-blockers.json"],
+        androidRequestBlocker: DomainBlocker(),
+        androidCosmeticBlocker: CosmeticBlocker()
+    )
+)
+```
+
+Platform behavior:
+
+- On iOS, `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList`s and attached to the web view's `WKUserContentController`.
+- SkipWeb persists compiled iOS rule lists in a cache keyed by source path and file contents, recompiles when a rule file changes, and prunes stale compiled entries when rule files are removed from the configuration.
+- iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` while building the configuration and through `WebEngine.contentBlockerSetupErrors` after engine creation.
+- When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
+- Popup children created with `platformContext.makeChildWebEngine(...)` inherit the mirrored content-blocker configuration.
+- On Android, `androidRequestBlocker` receives an `AndroidBlockableRequest` for intercepted resource loads and can return `.allow` or `.block`.
+- `AndroidBlockableRequest.isRedirect` is best-effort on Android and may be `nil` when the device's WebView runtime does not support redirect detection.
+- On Android, `androidCosmeticBlocker` can inject CSS at page start using `AndroidCosmeticPayload`.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ let config = WebEngineConfiguration(
         iOSRuleListPaths: [
             Bundle.main.path(forResource: "content-blockers", ofType: "json")!
         ],
-        androidRequestBlocker: MyAndroidRequestBlocker(),
-        androidCosmeticBlocker: MyAndroidCosmeticBlocker()
+        androidMode: .custom(MyAndroidContentBlockingProvider())
     )
 )
 ```
+
+For Android navigation callbacks, prefer `WebEngineConfiguration.navigationDelegate`.
+`WebEngine.engineDelegate` remains available as a deprecated compatibility escape hatch, but SkipWeb now keeps blocker enforcement on an internal engine-owned `WebViewClient`.
 
 Navigation APIs:
 
@@ -572,30 +574,30 @@ Platform behavior:
 Supporting types:
 
 - `WebContentBlockerConfiguration`
-- `AndroidRequestBlocker`
+- `AndroidContentBlockingMode`
+- `AndroidContentBlockingProvider`
 - `AndroidBlockableRequest`
 - `AndroidRequestBlockDecision`
-- `AndroidCosmeticBlocker`
 - `AndroidPageContext`
 - `AndroidCosmeticRule`
 - `AndroidCosmeticFrameScope`
 - `AndroidCosmeticInjectionTiming`
+- `AndroidRequestBlocker` (deprecated compatibility shim)
+- `AndroidCosmeticBlocker` (deprecated compatibility shim)
 - `WebContentBlockerError`
 
 Example:
 
 ```swift
-struct DomainBlocker: AndroidRequestBlocker {
-    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+struct CustomBlockingProvider: AndroidContentBlockingProvider {
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
         if request.url.host?.contains("ads") == true {
             return .block
         }
         return .allow
     }
-}
 
-struct CosmeticBlocker: AndroidCosmeticBlocker {
-    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
         [
             AndroidCosmeticRule(
                 hiddenSelectors: [
@@ -624,11 +626,12 @@ struct CosmeticBlocker: AndroidCosmeticBlocker {
 let config = WebEngineConfiguration(
     contentBlockers: WebContentBlockerConfiguration(
         iOSRuleListPaths: ["/path/to/content-blockers.json"],
-        androidRequestBlocker: DomainBlocker(),
-        androidCosmeticBlocker: CosmeticBlocker()
+        androidMode: .custom(CustomBlockingProvider())
     )
 )
 ```
+
+`androidRequestBlocker` and `androidCosmeticBlocker` remain available as deprecated compatibility shims for one release, but new integrations should prefer `androidMode`.
 
 Platform behavior:
 
@@ -637,9 +640,10 @@ Platform behavior:
 - iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` while building the configuration and through `WebEngine.contentBlockerSetupErrors` after engine creation.
 - When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
 - Popup children created with `platformContext.makeChildWebEngine(...)` inherit the mirrored content-blocker configuration.
-- On Android, `androidRequestBlocker` receives an `AndroidBlockableRequest` for intercepted resource loads and can return `.allow` or `.block`.
+- On Android, SkipWeb now installs an engine-owned `WebViewClient` so content blocking stays active for `WebView`, popup children, and direct/headless `WebEngine` usage.
+- On Android, `.custom(...)` receives an `AndroidBlockableRequest` for intercepted resource loads and can return `.allow` or `.block`.
 - `AndroidBlockableRequest.isRedirect` is best-effort on Android and may be `nil` when the device's WebView runtime does not support redirect detection.
-- On Android, `androidCosmeticBlocker` returns ordered `AndroidCosmeticRule` values. Each rule can scope CSS to matching frame document URLs with `urlFilterPattern`, scope frame origins with `allowedOriginRules`, control frame scope with `frameScope`, and prefer `.documentStart` or `.pageLifecycle` injection timing.
+- On Android, `.custom(...)` also returns ordered `AndroidCosmeticRule` values. Each rule can scope CSS to matching frame document URLs with `urlFilterPattern`, scope frame origins with `allowedOriginRules`, control frame scope with `frameScope`, and prefer `.documentStart` or `.pageLifecycle` injection timing.
 - `AndroidCosmeticRule(hiddenSelectors: ...)` is the convenience path for iOS-style cosmetic hiding and expands each selector to `display: none !important;`.
 - `AndroidCosmeticFrameScope` supports `.mainFrameOnly` (the default), `.subframesOnly`, and `.allFrames`. Use `.subframesOnly` when you want CSS to apply only inside iframe/frame documents instead of the top-level page.
 - Subframe-targeted Android cosmetic rules require document-start script injection. If Android cannot install document-start scripts, SkipWeb only falls back main-frame `.documentStart` rules to page-lifecycle injection; `.subframesOnly` and `.allFrames` rules are skipped in that situation.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ let config = WebEngineConfiguration(
         androidMode: .custom(MyAndroidContentBlockingProvider())
     )
 )
+
+_ = await config.prepareContentBlockers()
 ```
 
 For Android navigation callbacks, prefer `WebEngineConfiguration.navigationDelegate`.
@@ -579,10 +581,11 @@ For a fuller guide with a quick integration example, whitelist behavior, and up-
 
 Quick summary:
 
-- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and attached to the web view's `WKUserContentController`.
+- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and attached by SkipWeb.
 - `whitelistedDomains` accepts WebKit-style entries such as `example.com` and `*.example.com`, normalizes them, and disables blocking for matching page domains across both platforms.
 - `androidMode: .custom(...)` is the primary Android API; the legacy `androidRequestBlocker` and `androidCosmeticBlocker` shims remain available as deprecated compatibility paths for one release.
 - `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list cache so the next install recompiles from source.
+- `prepareContentBlockers()` lets apps prewarm iOS blocker setup without importing `WebKit`.
 - Popup children and caller-supplied `WKWebView` instances inherit the configured blocker setup.
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -574,8 +574,12 @@ Supporting types:
 - `WebContentBlockerConfiguration`
 - `AndroidRequestBlocker`
 - `AndroidBlockableRequest`
+- `AndroidRequestBlockDecision`
 - `AndroidCosmeticBlocker`
-- `AndroidCosmeticPayload`
+- `AndroidPageContext`
+- `AndroidCosmeticRule`
+- `AndroidCosmeticFrameScope`
+- `AndroidCosmeticInjectionTiming`
 - `WebContentBlockerError`
 
 Example:
@@ -591,10 +595,29 @@ struct DomainBlocker: AndroidRequestBlocker {
 }
 
 struct CosmeticBlocker: AndroidCosmeticBlocker {
-    func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload? {
-        AndroidCosmeticPayload(css: [
-            ".ad-banner { display: none !important; }"
-        ])
+    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        [
+            AndroidCosmeticRule(
+                hiddenSelectors: [
+                    ".ad-banner"
+                ]
+            ),
+            AndroidCosmeticRule(
+                hiddenSelectors: [
+                    ".ad-slot",
+                    ".tracking-frame"
+                ],
+                urlFilterPattern: ".*\\/ad-frame\\.html",
+                allowedOriginRules: ["https://*.doubleclick.net"],
+                frameScope: .subframesOnly
+            ),
+            AndroidCosmeticRule(
+                css: [
+                    "body.modal-open { overflow: auto !important; }"
+                ],
+                preferredTiming: .pageLifecycle
+            )
+        ]
     }
 }
 
@@ -616,7 +639,13 @@ Platform behavior:
 - Popup children created with `platformContext.makeChildWebEngine(...)` inherit the mirrored content-blocker configuration.
 - On Android, `androidRequestBlocker` receives an `AndroidBlockableRequest` for intercepted resource loads and can return `.allow` or `.block`.
 - `AndroidBlockableRequest.isRedirect` is best-effort on Android and may be `nil` when the device's WebView runtime does not support redirect detection.
-- On Android, `androidCosmeticBlocker` can inject CSS at page start using `AndroidCosmeticPayload`.
+- On Android, `androidCosmeticBlocker` returns ordered `AndroidCosmeticRule` values. Each rule can scope CSS to matching frame document URLs with `urlFilterPattern`, scope frame origins with `allowedOriginRules`, control frame scope with `frameScope`, and prefer `.documentStart` or `.pageLifecycle` injection timing.
+- `AndroidCosmeticRule(hiddenSelectors: ...)` is the convenience path for iOS-style cosmetic hiding and expands each selector to `display: none !important;`.
+- `AndroidCosmeticFrameScope` supports `.mainFrameOnly` (the default), `.subframesOnly`, and `.allFrames`. Use `.subframesOnly` when you want CSS to apply only inside iframe/frame documents instead of the top-level page.
+- Subframe-targeted Android cosmetic rules require document-start script injection. If Android cannot install document-start scripts, SkipWeb only falls back main-frame `.documentStart` rules to page-lifecycle injection; `.subframesOnly` and `.allFrames` rules are skipped in that situation.
+- `.pageLifecycle` injection is main-frame-only on Android. If you need to target subframes, keep `preferredTiming` at `.documentStart`.
+- Same-document navigations on Android, such as `history.pushState`, `history.replaceState`, and hash-only URL changes, do not currently refresh URL-scoped cosmetic rules. Treat `urlFilterPattern` matching as navigation-time behavior rather than a live SPA routing hook.
+- Keep using `css:` when you need more than hiding, such as layout repair or `pointer-events` fixes after removing an overlay.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -629,6 +629,8 @@ let config = WebEngineConfiguration(
         androidMode: .custom(CustomBlockingProvider())
     )
 )
+
+try WebEngineConfiguration.clearContentBlockerCache()
 ```
 
 `androidRequestBlocker` and `androidCosmeticBlocker` remain available as deprecated compatibility shims for one release, but new integrations should prefer `androidMode`.
@@ -637,6 +639,7 @@ Platform behavior:
 
 - On iOS, `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList`s and attached to the web view's `WKUserContentController`.
 - SkipWeb persists compiled iOS rule lists in a cache keyed by source path and file contents, recompiles when a rule file changes, and prunes stale compiled entries when rule files are removed from the configuration.
+- Call `WebEngineConfiguration.clearContentBlockerCache()` to explicitly remove the persisted iOS rule-list cache and force recompilation on the next install. On Android this API is a no-op.
 - On iOS, create configured `WKWebViewConfiguration` instances with `await WebEngineConfiguration.makeWebViewConfiguration()`, which compiles and installs any configured rule lists before returning.
 - iOS blocker setup errors are exposed through `WebEngineConfiguration.contentBlockerSetupErrors` after `makeWebViewConfiguration()` completes and through `await WebEngine.awaitContentBlockerSetup()` / `WebEngine.contentBlockerSetupErrors` after engine creation.
 - When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.

--- a/SkipWebContentBlockers.md
+++ b/SkipWebContentBlockers.md
@@ -15,6 +15,12 @@ import WebKit
 import SkipWeb
 
 struct ContentBlockingProvider: AndroidContentBlockingProvider {
+    var persistentCosmeticRules: [AndroidCosmeticRule] {
+        [
+            AndroidCosmeticRule(hiddenSelectors: [".ad-banner"])
+        ]
+    }
+
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
         if request.url.host?.contains("ads") == true {
             return .block
@@ -22,9 +28,8 @@ struct ContentBlockingProvider: AndroidContentBlockingProvider {
         return .allow
     }
 
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
         [
-            AndroidCosmeticRule(hiddenSelectors: [".ad-banner"]),
             AndroidCosmeticRule(
                 hiddenSelectors: [".ad-slot", ".tracking-frame"],
                 urlFilterPattern: ".*\\/ad-frame\\.html",
@@ -48,6 +53,7 @@ let configuration = WebEngineConfiguration(
 )
 
 try WebEngineConfiguration.clearContentBlockerCache()
+_ = await configuration.prepareContentBlockers()
 let webViewConfiguration = await configuration.makeWebViewConfiguration()
 let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
 let engine = WebEngine(configuration: configuration, webView: webView)
@@ -82,10 +88,8 @@ public final class WebEngineConfiguration {
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]
 
     @MainActor public static func clearContentBlockerCache() throws
+    @MainActor public func prepareContentBlockers() async -> [WebContentBlockerError]
     @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration
-    @MainActor public func installContentBlockers(
-        into userContentController: WKUserContentController
-    ) async -> [WebContentBlockerError]
 }
 ```
 
@@ -103,8 +107,9 @@ public final class WebEngine {
 
 ```swift
 public protocol AndroidContentBlockingProvider {
+    var persistentCosmeticRules: [AndroidCosmeticRule] { get }
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
 }
 ```
 
@@ -232,12 +237,21 @@ public protocol AndroidCosmeticBlocker {
 
 `AndroidCosmeticBlocker` remains available as a deprecated compatibility shim for one release, but the primary API is `androidMode: .custom(...)`.
 
+Think of Android cosmetics as two buckets:
+- `persistentCosmeticRules`: a long-lived baseline registered once per `WebView` and reused across navigations when it does not change
+- `navigationCosmeticRules(for:)`: page-specific CSS that is refreshed for each main-frame navigation when needed
+
+This split is mainly about avoiding repeated work. Think of it as "install the baseline once, then only swap the delta when the page changes." Rules that are effectively global to the browsing session belong in `persistentCosmeticRules`; rules that depend on the current page URL, host, or dynamic match context belong in `navigationCosmeticRules(for:)`.
+
+Whitelist opt-out is enforced inside `SkipWeb`'s Android controller. If the current main-frame URL matches `whitelistedDomains`, neither the persistent baseline nor the per-navigation delta is applied.
+
 ## iOS Rule-List Notes
 
-- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and installed on the `WKUserContentController`.
+- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and installed by SkipWeb.
 - SkipWeb persists compiled iOS rule lists in a cache keyed by source path plus effective compiled content.
 - `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list store.
-- `contentBlockerSetupErrors` is populated after `makeWebViewConfiguration()` and after `awaitContentBlockerSetup()`.
+- `prepareContentBlockers()` lets apps prewarm iOS rule-list compilation without touching WebKit types directly.
+- `contentBlockerSetupErrors` is populated after `prepareContentBlockers()`, after `makeWebViewConfiguration()`, and after `awaitContentBlockerSetup()`.
 - When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
 
 ### Whitelist Injection

--- a/SkipWebContentBlockers.md
+++ b/SkipWebContentBlockers.md
@@ -37,8 +37,9 @@ struct ContentBlockingProvider: AndroidContentBlockingProvider {
                 frameScope: .subframesOnly
             ),
             AndroidCosmeticRule(
-                css: ["body.modal-open { overflow: auto !important; }"],
-                preferredTiming: .pageLifecycle
+                hiddenSelectors: [".generic-overlay", "#sponsored-modal"],
+                preferredTiming: .pageLifecycle,
+                frameScope: .mainFrameOnly
             )
         ]
     }
@@ -205,29 +206,27 @@ public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Send
 
 ```swift
 public struct AndroidCosmeticRule: Equatable, Sendable {
-    public var css: [String]
+    public var hiddenSelectors: [String]
     public var urlFilterPattern: String?
     public var allowedOriginRules: [String]
+    public var ifDomainList: [String]
+    public var unlessDomainList: [String]
     public var frameScope: AndroidCosmeticFrameScope
     public var preferredTiming: AndroidCosmeticInjectionTiming
 
     public init(
-        css: [String] = [],
+        hiddenSelectors: [String] = [],
         urlFilterPattern: String? = nil,
         allowedOriginRules: [String] = ["*"],
-        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
-        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
-    )
-
-    public init(
-        hiddenSelectors: [String],
-        urlFilterPattern: String? = nil,
-        allowedOriginRules: [String] = ["*"],
+        ifDomainList: [String] = [],
+        unlessDomainList: [String] = [],
         frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
         preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
     )
 }
 ```
+
+Think of the Android cosmetic API as "selectors plus guards". `SkipWeb` is responsible for turning those selectors into `display: none !important` when a frame actually matches.
 
 ```swift
 public protocol AndroidCosmeticBlocker {

--- a/SkipWebContentBlockers.md
+++ b/SkipWebContentBlockers.md
@@ -49,12 +49,13 @@ let configuration = WebEngineConfiguration(
     contentBlockers: WebContentBlockerConfiguration(
         iOSRuleListPaths: ["/path/to/content-blockers.json"],
         whitelistedDomains: ["example.com", "*.example.org"],
+        popupWhitelistedSourceDomains: ["example.com"],
         androidMode: .custom(ContentBlockingProvider())
     )
 )
 
-try WebEngineConfiguration.clearContentBlockerCache()
-_ = await configuration.prepareContentBlockers()
+try WebEngineConfiguration.iOSClearContentBlockerCache()
+_ = await configuration.iOSPrepareContentBlockers()
 let webViewConfiguration = await configuration.makeWebViewConfiguration()
 let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
 let engine = WebEngine(configuration: configuration, webView: webView)
@@ -67,18 +68,14 @@ _ = await engine.awaitContentBlockerSetup()
 public struct WebContentBlockerConfiguration {
     public var iOSRuleListPaths: [String]
     public var whitelistedDomains: [String]
+    public var popupWhitelistedSourceDomains: [String]
     public var androidMode: AndroidContentBlockingMode
-    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
-    public var androidRequestBlocker: (any AndroidRequestBlocker)?
-    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
-    public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
 
     public init(
         iOSRuleListPaths: [String] = [],
         whitelistedDomains: [String] = [],
-        androidMode: AndroidContentBlockingMode = .disabled,
-        androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
-        androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
+        popupWhitelistedSourceDomains: [String] = [],
+        androidMode: AndroidContentBlockingMode = .disabled
     )
 }
 ```
@@ -88,8 +85,8 @@ public final class WebEngineConfiguration {
     public var contentBlockers: WebContentBlockerConfiguration?
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]
 
-    @MainActor public static func clearContentBlockerCache() throws
-    @MainActor public func prepareContentBlockers() async -> [WebContentBlockerError]
+    @MainActor public static func iOSClearContentBlockerCache() throws
+    @MainActor public func iOSPrepareContentBlockers() async -> [WebContentBlockerError]
     @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration
 }
 ```
@@ -170,14 +167,6 @@ public struct AndroidBlockableRequest: Equatable, Sendable {
 }
 ```
 
-```swift
-public protocol AndroidRequestBlocker {
-    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
-}
-```
-
-`AndroidRequestBlocker` remains available as a deprecated compatibility shim for one release, but the primary API is `androidMode: .custom(...)`.
-
 ### Cosmetic Blocking
 
 ```swift
@@ -228,13 +217,22 @@ public struct AndroidCosmeticRule: Equatable, Sendable {
 
 Think of the Android cosmetic API as "selectors plus guards". `SkipWeb` is responsible for turning those selectors into `display: none !important` when a frame actually matches.
 
+Practical example:
+
 ```swift
-public protocol AndroidCosmeticBlocker {
-    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
-}
+AndroidCosmeticRule(
+    hiddenSelectors: [".ad-slot", ".tracking-frame"],
+    urlFilterPattern: ".*\\/ad-frame\\.html",
+    allowedOriginRules: ["https://*.doubleclick.net"],
+    frameScope: .subframesOnly
+)
 ```
 
-`AndroidCosmeticBlocker` remains available as a deprecated compatibility shim for one release, but the primary API is `androidMode: .custom(...)`.
+Think of that rule as:
+- register this document-start script only for `https://*.doubleclick.net`
+- then, inside those matching subframes, only apply the CSS when the current frame URL also matches `.*\\/ad-frame\\.html`
+
+`allowedOriginRules` is the registration-time scope. Android's `WebViewCompat.addDocumentStartJavaScript(...)` requires those origin rules up front, so SkipWeb cannot infer them later inside the script. `urlFilterPattern`, `ifDomainList`, and `unlessDomainList` are the runtime frame guards checked by the injected script after it has been installed.
 
 Think of Android cosmetics as two buckets:
 - `persistentCosmeticRules`: a long-lived baseline registered once per `WebView` and reused across navigations when it does not change
@@ -248,9 +246,9 @@ Whitelist opt-out is enforced inside `SkipWeb`'s Android controller. If the curr
 
 - `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and installed by SkipWeb.
 - SkipWeb persists compiled iOS rule lists in a cache keyed by source path plus effective compiled content.
-- `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list store.
-- `prepareContentBlockers()` lets apps prewarm iOS rule-list compilation without touching WebKit types directly.
-- `contentBlockerSetupErrors` is populated after `prepareContentBlockers()`, after `makeWebViewConfiguration()`, and after `awaitContentBlockerSetup()`.
+- `WebEngineConfiguration.iOSClearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list store.
+- `iOSPrepareContentBlockers()` lets apps prewarm iOS rule-list compilation without touching WebKit types directly.
+- `contentBlockerSetupErrors` is populated after `iOSPrepareContentBlockers()`, after `makeWebViewConfiguration()`, and after `awaitContentBlockerSetup()`.
 - When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
 
 ### Whitelist Injection
@@ -274,13 +272,41 @@ Generated rule shape:
 
 Caller-owned rule files on disk are not modified.
 
+### Popup Whitelist Injection
+
+`popupWhitelistedSourceDomains` is the popup-only override path. SkipWeb normalizes those entries and appends an in-memory popup exemption rule to each compiled iOS rule file when the popup whitelist is non-empty.
+
+Generated rule shape:
+
+```json
+{
+  "comment": "user-injected popup exemptions (allowed source domains)",
+  "trigger": {
+    "url-filter": ".*",
+    "resource-type": ["popup"],
+    "if-top-url": [
+      "https://example.com/*",
+      "https://*.example.com/*"
+    ]
+  },
+  "action": {
+    "type": "ignore-previous-rules"
+  }
+}
+```
+
+This is source-site based, not popup-target based. Think of it as "allow popups from this site" rather than "allow popups to this destination."
+
 ## Cross-Platform Whitelist Semantics
 
 - `whitelistedDomains` entries are trimmed, lowercased, deduplicated, and sorted before use.
+- `popupWhitelistedSourceDomains` entries are trimmed, lowercased, deduplicated, and sorted before use.
 - Exact entries like `example.com` match only that host.
 - Wildcard entries like `*.example.com` match subdomains of `example.com`.
 - Exact entries do not implicitly match subdomains.
 - On Android, matching whitelisted page domains bypass request blocking and suppress cosmetic rules for the current page while leaving the caller's custom provider unchanged for non-whitelisted domains.
+- `popupWhitelistedSourceDomains` uses site-level matching instead of exact-host matching: a bare entry like `example.com` covers both `example.com` and common subdomains such as `www.example.com`, while `*.example.com` remains subdomains-only.
+- On Android, matching popup source domains bypass popup blocking only; normal request and cosmetic blocking still use `whitelistedDomains`.
 
 ## Error Reporting
 

--- a/SkipWebContentBlockers.md
+++ b/SkipWebContentBlockers.md
@@ -1,0 +1,286 @@
+# SkipWeb Content Blockers
+
+`SkipWeb` exposes portable content-blocking hooks through `WebEngineConfiguration.contentBlockers`.
+
+Use this guide when you need:
+- a quick integration example
+- the current public API shape for blocker-related types
+- platform notes for iOS rule lists, Android request/cosmetic blocking, and domain whitelisting
+
+## Quick Usage Example
+
+```swift
+import Foundation
+import WebKit
+import SkipWeb
+
+struct ContentBlockingProvider: AndroidContentBlockingProvider {
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+        if request.url.host?.contains("ads") == true {
+            return .block
+        }
+        return .allow
+    }
+
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        [
+            AndroidCosmeticRule(hiddenSelectors: [".ad-banner"]),
+            AndroidCosmeticRule(
+                hiddenSelectors: [".ad-slot", ".tracking-frame"],
+                urlFilterPattern: ".*\\/ad-frame\\.html",
+                allowedOriginRules: ["https://*.doubleclick.net"],
+                frameScope: .subframesOnly
+            ),
+            AndroidCosmeticRule(
+                css: ["body.modal-open { overflow: auto !important; }"],
+                preferredTiming: .pageLifecycle
+            )
+        ]
+    }
+}
+
+let configuration = WebEngineConfiguration(
+    contentBlockers: WebContentBlockerConfiguration(
+        iOSRuleListPaths: ["/path/to/content-blockers.json"],
+        whitelistedDomains: ["example.com", "*.example.org"],
+        androidMode: .custom(ContentBlockingProvider())
+    )
+)
+
+try WebEngineConfiguration.clearContentBlockerCache()
+let webViewConfiguration = await configuration.makeWebViewConfiguration()
+let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+let engine = WebEngine(configuration: configuration, webView: webView)
+_ = await engine.awaitContentBlockerSetup()
+```
+
+## Configuration Surface
+
+```swift
+public struct WebContentBlockerConfiguration {
+    public var iOSRuleListPaths: [String]
+    public var whitelistedDomains: [String]
+    public var androidMode: AndroidContentBlockingMode
+    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
+    public var androidRequestBlocker: (any AndroidRequestBlocker)?
+    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
+    public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
+
+    public init(
+        iOSRuleListPaths: [String] = [],
+        whitelistedDomains: [String] = [],
+        androidMode: AndroidContentBlockingMode = .disabled,
+        androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
+        androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
+    )
+}
+```
+
+```swift
+public final class WebEngineConfiguration {
+    public var contentBlockers: WebContentBlockerConfiguration?
+    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]
+
+    @MainActor public static func clearContentBlockerCache() throws
+    @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration
+    @MainActor public func installContentBlockers(
+        into userContentController: WKUserContentController
+    ) async -> [WebContentBlockerError]
+}
+```
+
+```swift
+public final class WebEngine {
+    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]
+
+    public func awaitContentBlockerSetup() async -> [WebContentBlockerError]
+}
+```
+
+## Android Content Blocking
+
+### Mode And Provider
+
+```swift
+public protocol AndroidContentBlockingProvider {
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+}
+```
+
+```swift
+public enum AndroidContentBlockingMode {
+    case disabled
+    case custom(any AndroidContentBlockingProvider)
+}
+```
+
+### Request Blocking
+
+```swift
+public enum AndroidRequestBlockDecision: Equatable, Sendable {
+    case allow
+    case block
+}
+```
+
+```swift
+public enum AndroidResourceTypeHint: String, CaseIterable, Hashable, Sendable {
+    case document
+    case subdocument
+    case stylesheet
+    case script
+    case image
+    case font
+    case media
+    case xhr
+    case fetch
+    case websocket
+    case other
+}
+```
+
+```swift
+public struct AndroidBlockableRequest: Equatable, Sendable {
+    public var url: URL
+    public var mainDocumentURL: URL?
+    public var method: String
+    public var headers: [String: String]
+    public var isForMainFrame: Bool
+    public var hasGesture: Bool
+    public var isRedirect: Bool?
+    public var resourceTypeHint: AndroidResourceTypeHint?
+
+    public init(
+        url: URL,
+        mainDocumentURL: URL? = nil,
+        method: String,
+        headers: [String: String] = [:],
+        isForMainFrame: Bool,
+        hasGesture: Bool,
+        isRedirect: Bool? = nil,
+        resourceTypeHint: AndroidResourceTypeHint? = nil
+    )
+}
+```
+
+```swift
+public protocol AndroidRequestBlocker {
+    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
+}
+```
+
+`AndroidRequestBlocker` remains available as a deprecated compatibility shim for one release, but the primary API is `androidMode: .custom(...)`.
+
+### Cosmetic Blocking
+
+```swift
+public struct AndroidPageContext: Equatable, Sendable {
+    public var url: URL
+    public var host: String?
+
+    public init(url: URL, host: String? = nil)
+}
+```
+
+```swift
+public enum AndroidCosmeticFrameScope: String, CaseIterable, Hashable, Sendable {
+    case mainFrameOnly
+    case subframesOnly
+    case allFrames
+}
+```
+
+```swift
+public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Sendable {
+    case documentStart
+    case pageLifecycle
+}
+```
+
+```swift
+public struct AndroidCosmeticRule: Equatable, Sendable {
+    public var css: [String]
+    public var urlFilterPattern: String?
+    public var allowedOriginRules: [String]
+    public var frameScope: AndroidCosmeticFrameScope
+    public var preferredTiming: AndroidCosmeticInjectionTiming
+
+    public init(
+        css: [String] = [],
+        urlFilterPattern: String? = nil,
+        allowedOriginRules: [String] = ["*"],
+        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
+        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
+    )
+
+    public init(
+        hiddenSelectors: [String],
+        urlFilterPattern: String? = nil,
+        allowedOriginRules: [String] = ["*"],
+        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
+        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
+    )
+}
+```
+
+```swift
+public protocol AndroidCosmeticBlocker {
+    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+}
+```
+
+`AndroidCosmeticBlocker` remains available as a deprecated compatibility shim for one release, but the primary API is `androidMode: .custom(...)`.
+
+## iOS Rule-List Notes
+
+- `iOSRuleListPaths` points to WebKit content-blocker JSON files that are compiled into `WKContentRuleList` values and installed on the `WKUserContentController`.
+- SkipWeb persists compiled iOS rule lists in a cache keyed by source path plus effective compiled content.
+- `WebEngineConfiguration.clearContentBlockerCache()` explicitly removes the persisted iOS compiled rule-list store.
+- `contentBlockerSetupErrors` is populated after `makeWebViewConfiguration()` and after `awaitContentBlockerSetup()`.
+- When you create a `WebEngine` with an already-constructed `WKWebView`, SkipWeb installs configured content blockers into that supplied web view as well.
+
+### Whitelist Injection
+
+`whitelistedDomains` accepts WebKit-style host entries such as `example.com` and `*.example.com`. SkipWeb normalizes those entries, then appends an in-memory exemption rule to each compiled iOS rule file when the whitelist is non-empty.
+
+Generated rule shape:
+
+```json
+{
+  "comment": "user-injected domain exemptions (whitelisted domains)",
+  "trigger": {
+    "url-filter": ".*",
+    "if-domain": ["example.com", "*.example.org"]
+  },
+  "action": {
+    "type": "ignore-previous-rules"
+  }
+}
+```
+
+Caller-owned rule files on disk are not modified.
+
+## Cross-Platform Whitelist Semantics
+
+- `whitelistedDomains` entries are trimmed, lowercased, deduplicated, and sorted before use.
+- Exact entries like `example.com` match only that host.
+- Wildcard entries like `*.example.com` match subdomains of `example.com`.
+- Exact entries do not implicitly match subdomains.
+- On Android, matching whitelisted page domains bypass request blocking and suppress cosmetic rules for the current page while leaving the caller's custom provider unchanged for non-whitelisted domains.
+
+## Error Reporting
+
+```swift
+public enum WebContentBlockerError: Error, Equatable, LocalizedError {
+    case storeUnavailable(String)
+    case fileReadFailed(path: String, description: String)
+    case fileEncodingFailed(path: String)
+    case cacheLookupFailed(identifier: String, description: String)
+    case compilationFailed(path: String, description: String)
+    case metadataReadFailed(String)
+    case metadataWriteFailed(String)
+    case staleRuleRemovalFailed(identifier: String, description: String)
+    case operationTimedOut(String)
+}
+```

--- a/SkipWebUIDelegate.md
+++ b/SkipWebUIDelegate.md
@@ -22,6 +22,8 @@ public protocol SkipWebUIDelegate: AnyObject {
 - `webView(_:createWebViewWith:platformContext:)`
   - Return `nil` to deny popup creation.
   - Return a child `WebEngine` to allow popup creation.
+  - Without `WebEngineConfiguration.uiDelegate`, `_blank` / `window.open(...)` uses platform fallback behavior:
+    iOS denies the popup request, while Android may navigate the current `WebView`.
   - `request.targetURL` may be `nil` on Android at creation time.
 - `webViewDidClose(_:child:)`
   - Called when a previously-created child window is closed via javascript (`window.close()`).

--- a/SkipWebUIDelegate.md
+++ b/SkipWebUIDelegate.md
@@ -128,6 +128,7 @@ struct PopupHostView: View {
 - If this contract is violated, WebKit can raise `NSInternalInconsistencyException` with: `Returned WKWebView was not created with the given configuration.`
 - For iOS popup creation, return a child created via `platformContext.makeChildWebEngine(...)`.
 - `makeChildWebEngine()` mirrors the parent `WebEngineConfiguration` and inspectability by default. Pass an explicit configuration only when you intentionally want different child behavior.
+- Mirrored popup configuration includes `contentBlockers`, so child engines created this way inherit the parent's blocker setup.
 - `makeChildWebEngine()` does not automatically copy platform delegate assignments (`WKUIDelegate`, `WKNavigationDelegate`) from the parent web view; assign those explicitly when needed.
 - On Android, after your delegate returns a child `WebEngine`, SkipWeb mirrors key parent web settings and inherits the parent `WebProfile` onto that child; if profile inheritance fails, popup creation is denied.
 - `PlatformCreateWindowContext` aliases `WebKitCreateWindowParams` on iOS and `AndroidCreateWindowParams` on Android.

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -150,15 +150,41 @@ public enum WebProfileError: Error, Equatable {
     case profileSetupFailed
 }
 
+/// Cross-platform content-blocker configuration for a `WebEngine`.
+///
+/// Think of it as the single place where apps describe:
+/// - iOS rule-list files to compile and install
+/// - domains that should bypass blocking entirely
+/// - Android request and cosmetic blocking behavior
 public struct WebContentBlockerConfiguration {
+    /// Paths to iOS WebKit content-blocker JSON files.
+    ///
+    /// SkipWeb compiles these files into `WKContentRuleList` values and installs them
+    /// into the web view configuration on Apple platforms.
     public var iOSRuleListPaths: [String]
+    /// Domain allowlist entries that bypass SkipWeb-managed blocking on matching pages.
+    ///
+    /// Entries use WebKit-style host matching such as `example.com` and `*.example.com`.
     public var whitelistedDomains: [String]
+    /// Primary Android content-blocking entry point.
+    ///
+    /// Use `.custom(...)` to supply request and cosmetic blocking behavior from one provider.
     public var androidMode: AndroidContentBlockingMode
+    /// Deprecated Android request-blocking compatibility shim.
     @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
     public var androidRequestBlocker: (any AndroidRequestBlocker)?
+    /// Deprecated Android cosmetic-blocking compatibility shim.
     @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
     public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
 
+    /// Creates a content-blocker configuration.
+    ///
+    /// - Parameters:
+    ///   - iOSRuleListPaths: iOS WebKit content-blocker JSON files to compile.
+    ///   - whitelistedDomains: Host patterns that should bypass blocking.
+    ///   - androidMode: Primary Android blocking configuration.
+    ///   - androidRequestBlocker: Deprecated Android request blocker bridge.
+    ///   - androidCosmeticBlocker: Deprecated Android cosmetic blocker bridge.
     public init(
         iOSRuleListPaths: [String] = [],
         whitelistedDomains: [String] = [],
@@ -174,28 +200,45 @@ public struct WebContentBlockerConfiguration {
     }
 }
 
+/// Android request and cosmetic blocking provider used by `AndroidContentBlockingMode.custom`.
 public protocol AndroidContentBlockingProvider {
+    /// Long-lived cosmetic rules that SkipWeb can reuse across navigations.
+    ///
+    /// Put CSS here when it acts like a baseline for the whole browsing session rather than
+    /// a rule that depends on the current page URL.
     var persistentCosmeticRules: [AndroidCosmeticRule] { get }
+    /// Returns the request-blocking decision for an Android resource load.
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
+    /// Returns page-specific cosmetic rules for the current main-frame navigation.
+    ///
+    /// Think of this as the per-page delta that sits on top of `persistentCosmeticRules`.
     func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
 }
 
 public extension AndroidContentBlockingProvider {
+    /// Default request-blocking implementation that allows every request.
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
         .allow
     }
 }
 
+/// Android content-blocking mode used by `WebContentBlockerConfiguration`.
 public enum AndroidContentBlockingMode {
+    /// Disable SkipWeb-managed Android content blocking.
     case disabled
+    /// Use a custom provider for Android request and cosmetic blocking.
     case custom(any AndroidContentBlockingProvider)
 }
 
+/// Request-blocking decision returned by Android blocker providers.
 public enum AndroidRequestBlockDecision: Equatable, Sendable {
+    /// Allow the request to continue.
     case allow
+    /// Block the request and return an empty response.
     case block
 }
 
+/// Best-effort Android resource classification exposed to request blockers.
 public enum AndroidResourceTypeHint: String, CaseIterable, Hashable, Sendable {
     case document
     case subdocument
@@ -210,16 +253,26 @@ public enum AndroidResourceTypeHint: String, CaseIterable, Hashable, Sendable {
     case other
 }
 
+/// Android request details passed to request blockers.
 public struct AndroidBlockableRequest: Equatable, Sendable {
+    /// The URL being requested.
     public var url: URL
+    /// The current main document URL when known.
     public var mainDocumentURL: URL?
+    /// The HTTP method used for the request.
     public var method: String
+    /// HTTP headers captured from the Android request when available.
     public var headers: [String: String]
+    /// Whether Android marked this as a main-frame navigation.
     public var isForMainFrame: Bool
+    /// Whether the request was triggered by a user gesture.
     public var hasGesture: Bool
+    /// Whether Android marked this request as a redirect, when known.
     public var isRedirect: Bool?
+    /// Best-effort Android resource classification for the request.
     public var resourceTypeHint: AndroidResourceTypeHint?
 
+    /// Creates an Android request description for blocker evaluation.
     public init(
         url: URL,
         mainDocumentURL: URL? = nil,
@@ -241,78 +294,98 @@ public struct AndroidBlockableRequest: Equatable, Sendable {
     }
 }
 
+/// Deprecated compatibility protocol for Android request blocking.
 public protocol AndroidRequestBlocker {
+    /// Returns the request-blocking decision for an Android resource load.
     func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
 }
 
+/// Page details passed to Android cosmetic blockers.
 public struct AndroidPageContext: Equatable, Sendable {
+    /// The current page URL.
     public var url: URL
+    /// The page host, defaulting to `url.host`.
     public var host: String?
 
+    /// Creates a page context for Android cosmetic rule evaluation.
     public init(url: URL, host: String? = nil) {
         self.url = url
         self.host = host ?? url.host
     }
 }
 
+/// Frame scope for an Android cosmetic rule.
 public enum AndroidCosmeticFrameScope: String, CaseIterable, Hashable, Sendable {
+    /// Apply only in the top-level document.
     case mainFrameOnly
+    /// Apply only in subframes.
     case subframesOnly
+    /// Apply in both the top-level document and subframes.
     case allFrames
 }
 
+/// Preferred injection timing for an Android cosmetic rule.
 public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Sendable {
+    /// Install at document start when supported.
     case documentStart
+    /// Inject later during the page lifecycle.
     case pageLifecycle
 }
 
+/// Android cosmetic rule describing CSS to hide or scope.
 public struct AndroidCosmeticRule: Equatable, Sendable {
-    public var css: [String]
+    /// Selector or selector-list entries to hide with `display: none !important`.
+    public var hiddenSelectors: [String]
+    /// Optional regex-style URL filter that must match the page or frame URL.
     public var urlFilterPattern: String?
+    /// Allowed origin rules used for Android document-start script registration.
     public var allowedOriginRules: [String]
+    /// Host patterns that must match the page host.
+    public var ifDomainList: [String]
+    /// Host patterns that must not match the page host.
+    public var unlessDomainList: [String]
+    /// Frame scope for the injected CSS.
     public var frameScope: AndroidCosmeticFrameScope
+    /// Preferred injection timing for the CSS.
     public var preferredTiming: AndroidCosmeticInjectionTiming
 
+    /// Creates an Android cosmetic rule.
+    ///
+    /// `hiddenSelectors` is the public API shape; SkipWeb turns each selector into
+    /// `display: none !important` CSS internally.
     public init(
-        css: [String] = [],
+        hiddenSelectors: [String] = [],
         urlFilterPattern: String? = nil,
         allowedOriginRules: [String] = ["*"],
+        ifDomainList: [String] = [],
+        unlessDomainList: [String] = [],
         frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
         preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
     ) {
-        self.css = css
+        self.hiddenSelectors = Self.normalizedHiddenSelectors(hiddenSelectors)
         self.urlFilterPattern = urlFilterPattern
         self.allowedOriginRules = allowedOriginRules
+        self.ifDomainList = ifDomainList
+        self.unlessDomainList = unlessDomainList
         self.frameScope = frameScope
         self.preferredTiming = preferredTiming
     }
 
-    /// Convenience initializer for selector-based hiding, matching iOS `css-display-none`.
-    public init(
-        hiddenSelectors: [String],
-        urlFilterPattern: String? = nil,
-        allowedOriginRules: [String] = ["*"],
-        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
-        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
-    ) {
-        self.init(
-            css: Self.hideCSS(for: hiddenSelectors),
-            urlFilterPattern: urlFilterPattern,
-            allowedOriginRules: allowedOriginRules,
-            frameScope: frameScope,
-            preferredTiming: preferredTiming
-        )
-    }
-
-    fileprivate static func hideCSS(for selectors: [String]) -> [String] {
+    fileprivate static func normalizedHiddenSelectors(_ selectors: [String]) -> [String] {
         selectors
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+    }
+
+    fileprivate static func hideCSS(for selectors: [String]) -> [String] {
+        normalizedHiddenSelectors(selectors)
             .map { "\($0) { display: none !important; }" }
     }
 }
 
+/// Deprecated compatibility protocol for Android cosmetic blocking.
 public protocol AndroidCosmeticBlocker {
+    /// Returns cosmetic rules for the given page.
     func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
 }
 
@@ -341,6 +414,15 @@ public extension SkipWebNavigationDelegate {
 struct AndroidCosmeticInjectionPlan {
     var documentStartRules: [AndroidCosmeticRule] = []
     var lifecycleCSS: [String] = []
+}
+
+struct AndroidDocumentStartRuleBatchKey: Hashable {
+    let frameScope: AndroidCosmeticFrameScope
+    let preferredTiming: AndroidCosmeticInjectionTiming
+    let urlFilterPattern: String?
+    let allowedOriginRules: [String]
+    let ifDomainList: [String]
+    let unlessDomainList: [String]
 }
 
 fileprivate struct LegacyAndroidContentBlockingProvider: AndroidContentBlockingProvider {
@@ -515,15 +597,25 @@ extension WebContentBlockerConfiguration {
     #endif
 }
 
+/// Errors surfaced while preparing, caching, or installing content blockers.
 public enum WebContentBlockerError: Error, Equatable, LocalizedError {
+    /// SkipWeb could not create or access the persistent content-blocker store.
     case storeUnavailable(String)
+    /// SkipWeb could not read a configured content-blocker file.
     case fileReadFailed(path: String, description: String)
+    /// A configured content-blocker file was not valid UTF-8 text.
     case fileEncodingFailed(path: String)
+    /// SkipWeb could not look up a previously compiled rule list in the cache.
     case cacheLookupFailed(identifier: String, description: String)
+    /// WebKit failed to compile a rule-list file.
     case compilationFailed(path: String, description: String)
+    /// SkipWeb could not read the persistent metadata it uses to track compiled rule lists.
     case metadataReadFailed(String)
+    /// SkipWeb could not write the persistent metadata it uses to track compiled rule lists.
     case metadataWriteFailed(String)
+    /// SkipWeb could not prune a stale compiled rule list from the cache.
     case staleRuleRemovalFailed(identifier: String, description: String)
+    /// A content-blocker store operation did not finish before the timeout.
     case operationTimedOut(String)
 
     public var errorDescription: String? {
@@ -923,6 +1015,9 @@ extension WebCookie {
 @MainActor public class WebEngine : WebObjectBase {
     public let configuration: WebEngineConfiguration
     public let webView: PlatformWebView
+    /// The latest content-blocker setup errors observed by this engine.
+    ///
+    /// On iOS this is populated after asynchronous content-blocker preparation completes.
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
     #if !SKIP
     public override var description: String {
@@ -1145,6 +1240,10 @@ extension WebCookie {
         }
     }
 
+    /// Waits for any pending content-blocker setup work and returns the resulting errors.
+    ///
+    /// This matters mainly on iOS, where rule-list compilation and installation can happen
+    /// asynchronously after engine creation.
     public func awaitContentBlockerSetup() async -> [WebContentBlockerError] {
         #if !SKIP
         if let iosContentBlockerSetupTask {
@@ -1792,10 +1891,18 @@ extension WebCookie {
         }
     }
 
+    fileprivate static func normalizedAndroidCosmeticSelectors(_ hiddenSelectors: [String]) -> [String] {
+        AndroidCosmeticRule.normalizedHiddenSelectors(hiddenSelectors)
+    }
+
     fileprivate static func normalizedAndroidCosmeticCSS(_ cssRules: [String]) -> [String] {
         cssRules
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
+    }
+
+    fileprivate static func androidDisplayNoneCSSRules(forSelectors hiddenSelectors: [String]) -> [String] {
+        AndroidCosmeticRule.hideCSS(for: hiddenSelectors)
     }
 
     fileprivate static func normalizedAndroidAllowedOriginRules(_ allowedOriginRules: [String]) -> [String] {
@@ -1919,6 +2026,45 @@ extension WebCookie {
         return normalizedRules.contains { androidOriginRule($0, matches: pageURL) }
     }
 
+    fileprivate static func androidDomainRule(_ rule: String, matchesHost host: String) -> Bool {
+        let normalizedRule = rule.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedRule.isEmpty else {
+            return false
+        }
+        if normalizedRule.hasPrefix("*.") {
+            let suffix = String(normalizedRule.dropFirst(2))
+            guard !suffix.isEmpty else {
+                return false
+            }
+            return host.count > suffix.count && host.hasSuffix(".\(suffix)")
+        }
+        return host == normalizedRule
+    }
+
+    fileprivate static func androidDomainListsMatchPage(
+        ifDomainList: [String],
+        unlessDomainList: [String],
+        pageURL: URL
+    ) -> Bool {
+        let host = pageURL.host?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if !ifDomainList.isEmpty {
+            guard let host else {
+                return false
+            }
+            guard ifDomainList.contains(where: { androidDomainRule($0, matchesHost: host) }) else {
+                return false
+            }
+        }
+
+        if let host,
+           unlessDomainList.contains(where: { androidDomainRule($0, matchesHost: host) }) {
+            return false
+        }
+
+        return true
+    }
+
     fileprivate static func androidURLFilterPatternMatchesPage(_ urlFilterPattern: String?, pageURL: URL) -> Bool {
         guard let urlFilterPattern, !urlFilterPattern.isEmpty else {
             return true
@@ -1939,55 +2085,100 @@ extension WebCookie {
 
     fileprivate static func appendAndroidDocumentStartRule(
         _ rule: AndroidCosmeticRule,
-        to batchedRules: inout [AndroidCosmeticRule]
+        to batchedRules: inout [AndroidCosmeticRule],
+        indexByKey: inout [AndroidDocumentStartRuleBatchKey: Int]
     ) {
-        var matchingIndex: Int?
-        for index in batchedRules.indices {
-            let existingRule = batchedRules[index]
-            if existingRule.frameScope == rule.frameScope &&
-                existingRule.preferredTiming == rule.preferredTiming &&
-                existingRule.urlFilterPattern == rule.urlFilterPattern &&
-                existingRule.allowedOriginRules == rule.allowedOriginRules {
-                matchingIndex = index
-                break
-            }
-        }
+        let key = AndroidDocumentStartRuleBatchKey(
+            frameScope: rule.frameScope,
+            preferredTiming: rule.preferredTiming,
+            urlFilterPattern: rule.urlFilterPattern,
+            allowedOriginRules: rule.allowedOriginRules,
+            ifDomainList: rule.ifDomainList,
+            unlessDomainList: rule.unlessDomainList
+        )
 
-        if let matchingIndex {
-            batchedRules[matchingIndex].css.append(contentsOf: rule.css)
+        if let matchingIndex = indexByKey[key] {
+            batchedRules[matchingIndex].hiddenSelectors.append(contentsOf: rule.hiddenSelectors)
         } else {
+            indexByKey[key] = batchedRules.count
             batchedRules.append(rule)
         }
     }
 
-    static func androidCosmeticInjectionPlan(
+    fileprivate static func androidDocumentStartCosmeticRules(
+        rules: [AndroidCosmeticRule],
+        isDocumentStartSupported: Bool
+    ) -> [AndroidCosmeticRule] {
+        guard isDocumentStartSupported else {
+            return []
+        }
+
+        var batchedRules: [AndroidCosmeticRule] = []
+        batchedRules.reserveCapacity(rules.count)
+        var indexByKey: [AndroidDocumentStartRuleBatchKey: Int] = [:]
+
+        for rule in rules {
+            guard rule.preferredTiming == .documentStart else {
+                continue
+            }
+
+            let normalizedSelectors = normalizedAndroidCosmeticSelectors(rule.hiddenSelectors)
+            guard !normalizedSelectors.isEmpty else {
+                continue
+            }
+
+            var normalizedRule = rule
+            normalizedRule.hiddenSelectors = normalizedSelectors
+            normalizedRule.allowedOriginRules = normalizedAndroidAllowedOriginRules(rule.allowedOriginRules)
+            appendAndroidDocumentStartRule(
+                normalizedRule,
+                to: &batchedRules,
+                indexByKey: &indexByKey
+            )
+        }
+
+        return batchedRules
+    }
+
+    fileprivate static func androidLifecycleCosmeticCSS(
         rules: [AndroidCosmeticRule],
         pageURL: URL,
         isDocumentStartSupported: Bool,
         log: ((String) -> Void)? = nil
-    ) -> AndroidCosmeticInjectionPlan {
-        var plan = AndroidCosmeticInjectionPlan()
+    ) -> [String] {
+        var lifecycleCSS: [String] = []
 
         for rule in rules {
-            let normalizedCSS = normalizedAndroidCosmeticCSS(rule.css)
-            guard !normalizedCSS.isEmpty else {
+            let normalizedSelectors = normalizedAndroidCosmeticSelectors(rule.hiddenSelectors)
+            guard !normalizedSelectors.isEmpty else {
                 continue
             }
+            let normalizedCSS = androidDisplayNoneCSSRules(forSelectors: normalizedSelectors)
 
             switch rule.preferredTiming {
             case .documentStart:
-                if isDocumentStartSupported {
-                    var normalizedRule = rule
-                    normalizedRule.css = normalizedCSS
-                    normalizedRule.allowedOriginRules = normalizedAndroidAllowedOriginRules(rule.allowedOriginRules)
-                    appendAndroidDocumentStartRule(normalizedRule, to: &plan.documentStartRules)
-                } else if rule.frameScope == .mainFrameOnly,
-                          androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
-                          androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
-                    plan.lifecycleCSS.append(contentsOf: normalizedCSS)
+                guard !isDocumentStartSupported else {
+                    continue
+                }
+
+                if rule.frameScope == .mainFrameOnly,
+                   androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
+                   androidDomainListsMatchPage(
+                    ifDomainList: rule.ifDomainList,
+                    unlessDomainList: rule.unlessDomainList,
+                    pageURL: pageURL
+                   ),
+                   androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
+                    lifecycleCSS.append(contentsOf: normalizedCSS)
                 } else if rule.frameScope == .mainFrameOnly {
                     if !androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL) {
                         log?("Skipping Android cosmetic rule because page origin does not match allowedOriginRules")
+                    } else if !androidDomainListsMatchPage(
+                        ifDomainList: rule.ifDomainList,
+                        unlessDomainList: rule.unlessDomainList,
+                        pageURL: pageURL
+                    ) {
+                        log?("Skipping Android cosmetic rule because page host does not match domain lists")
                     } else {
                         log?("Skipping Android cosmetic rule because page URL does not match urlFilterPattern")
                     }
@@ -1997,11 +2188,22 @@ extension WebCookie {
             case .pageLifecycle:
                 if rule.frameScope == .mainFrameOnly,
                    androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
+                   androidDomainListsMatchPage(
+                    ifDomainList: rule.ifDomainList,
+                    unlessDomainList: rule.unlessDomainList,
+                    pageURL: pageURL
+                   ),
                    androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
-                    plan.lifecycleCSS.append(contentsOf: normalizedCSS)
+                    lifecycleCSS.append(contentsOf: normalizedCSS)
                 } else if rule.frameScope == .mainFrameOnly {
                     if !androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL) {
                         log?("Skipping Android cosmetic rule because page origin does not match allowedOriginRules")
+                    } else if !androidDomainListsMatchPage(
+                        ifDomainList: rule.ifDomainList,
+                        unlessDomainList: rule.unlessDomainList,
+                        pageURL: pageURL
+                    ) {
+                        log?("Skipping Android cosmetic rule because page host does not match domain lists")
                     } else {
                         log?("Skipping Android cosmetic rule because page URL does not match urlFilterPattern")
                     }
@@ -2011,7 +2213,27 @@ extension WebCookie {
             }
         }
 
-        return plan
+        return lifecycleCSS
+    }
+
+    static func androidCosmeticInjectionPlan(
+        rules: [AndroidCosmeticRule],
+        pageURL: URL,
+        isDocumentStartSupported: Bool,
+        log: ((String) -> Void)? = nil
+    ) -> AndroidCosmeticInjectionPlan {
+        AndroidCosmeticInjectionPlan(
+            documentStartRules: androidDocumentStartCosmeticRules(
+                rules: rules,
+                isDocumentStartSupported: isDocumentStartSupported
+            ),
+            lifecycleCSS: androidLifecycleCosmeticCSS(
+                rules: rules,
+                pageURL: pageURL,
+                isDocumentStartSupported: isDocumentStartSupported,
+                log: log
+            )
+        )
     }
 
     static func androidRedirectFallbackCosmeticPlan(
@@ -2043,7 +2265,9 @@ extension WebCookie {
         cssRules: [String],
         styleID: String,
         frameScope: AndroidCosmeticFrameScope,
-        urlFilterPattern: String? = nil
+        urlFilterPattern: String? = nil,
+        ifDomainList: [String] = [],
+        unlessDomainList: [String] = []
     ) -> String? {
         let css = normalizedAndroidCosmeticCSS(cssRules).joined(separator: "\n")
         guard !css.isEmpty else {
@@ -2076,6 +2300,39 @@ extension WebCookie {
         } else {
             urlFilterGuard = ""
         }
+        let domainGuard: String
+        if !ifDomainList.isEmpty || !unlessDomainList.isEmpty {
+            guard
+                let ifDomainData = try? JSONSerialization.data(withJSONObject: ifDomainList, options: []),
+                let ifDomainEncoded = String(data: ifDomainData, encoding: .utf8),
+                let unlessDomainData = try? JSONSerialization.data(withJSONObject: unlessDomainList, options: []),
+                let unlessDomainEncoded = String(data: unlessDomainData, encoding: .utf8)
+            else {
+                return nil
+            }
+            domainGuard = """
+            var currentHost = (window.location.hostname || "").toLowerCase();
+            var ifDomainList = \(ifDomainEncoded);
+            var unlessDomainList = \(unlessDomainEncoded);
+            var domainMatches = function(ruleDomain) {
+                if (typeof ruleDomain !== "string") { return false; }
+                var normalizedRuleDomain = ruleDomain.trim().toLowerCase();
+                if (!normalizedRuleDomain) { return false; }
+                if (normalizedRuleDomain.startsWith("*.")) {
+                    var suffix = normalizedRuleDomain.slice(2);
+                    return !!suffix && currentHost.length > suffix.length && currentHost.endsWith("." + suffix);
+                }
+                return currentHost === normalizedRuleDomain;
+            };
+            if (ifDomainList.length > 0) {
+                if (!currentHost) { return; }
+                if (!ifDomainList.some(domainMatches)) { return; }
+            }
+            if (currentHost && unlessDomainList.some(domainMatches)) { return; }
+            """
+        } else {
+            domainGuard = ""
+        }
         let frameGuard: String
         switch frameScope {
         case .mainFrameOnly:
@@ -2089,6 +2346,7 @@ extension WebCookie {
         (function() {
             \(frameGuard)
             \(urlFilterGuard)
+            \(domainGuard)
             var styleId = "\(styleIDLiteral)";
             var css = \(cssLiteral);
             var root = document.head || document.documentElement;
@@ -2100,6 +2358,169 @@ extension WebCookie {
                 root.appendChild(style);
             }
             style.textContent = css;
+        })();
+        """
+    }
+
+    static func androidContentBlockerBatchedStyleInjectionScript(
+        rules: [AndroidCosmeticRule],
+        styleID: String
+    ) -> String? {
+        var serializedRules: [[String: Any]] = []
+        serializedRules.reserveCapacity(rules.count)
+
+        for rule in rules {
+            let hiddenSelectors = normalizedAndroidCosmeticSelectors(rule.hiddenSelectors)
+            guard !hiddenSelectors.isEmpty else {
+                continue
+            }
+            serializedRules.append(
+                [
+                    "hiddenSelectors": hiddenSelectors,
+                    "frameScope": rule.frameScope.rawValue,
+                    "urlFilterPattern": rule.urlFilterPattern ?? NSNull(),
+                    "ifDomainList": rule.ifDomainList,
+                    "unlessDomainList": rule.unlessDomainList,
+                ]
+            )
+        }
+
+        guard !serializedRules.isEmpty else {
+            return nil
+        }
+        guard
+            let rulesData = try? JSONSerialization.data(withJSONObject: serializedRules, options: []),
+            let rulesLiteral = String(data: rulesData, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        let styleIDLiteral = styleID.replacingOccurrences(of: "\"", with: "\\\"")
+        return """
+        (function() {
+            var rules = \(rulesLiteral);
+            var locationHref = window.location.href || "";
+            var currentHost = (window.location.hostname || "").toLowerCase();
+            var collectedSelectors = [];
+            var displayNoneDeclaration = "display: none !important;";
+
+            var groupedDisplayNoneCSS = function(selectors) {
+                var maximumSelectorsPerGroupedRule = 128;
+                var maximumSelectorCharactersPerGroupedRule = 16384;
+                var groupedCSS = [];
+                var currentSelectors = [];
+                var currentSelectorCharacters = 0;
+
+                var flushCurrentSelectors = function() {
+                    if (currentSelectors.length === 0) { return; }
+                    groupedCSS.push(currentSelectors.join(", ") + " { " + displayNoneDeclaration + " }");
+                    currentSelectors = [];
+                    currentSelectorCharacters = 0;
+                };
+
+                for (var selectorIndex = 0; selectorIndex < selectors.length; selectorIndex += 1) {
+                    var selector = selectors[selectorIndex];
+                    var separatorCharacters = currentSelectors.length === 0 ? 0 : 2;
+                    var projectedSelectorCharacters = currentSelectorCharacters + separatorCharacters + selector.length;
+                    if (currentSelectors.length > 0 &&
+                        (currentSelectors.length >= maximumSelectorsPerGroupedRule ||
+                         projectedSelectorCharacters > maximumSelectorCharactersPerGroupedRule)) {
+                        flushCurrentSelectors();
+                    }
+
+                    currentSelectors.push(selector);
+                    currentSelectorCharacters += (currentSelectors.length === 1 ? 0 : 2) + selector.length;
+                }
+
+                flushCurrentSelectors();
+                return groupedCSS;
+            };
+
+            var compactHiddenSelectors = function(hiddenSelectors) {
+                var normalizedSelectors = [];
+                for (var selectorIndex = 0; selectorIndex < hiddenSelectors.length; selectorIndex += 1) {
+                    var hiddenSelector = hiddenSelectors[selectorIndex];
+                    if (typeof hiddenSelector !== "string") { continue; }
+                    var normalizedSelector = hiddenSelector.trim();
+                    if (!normalizedSelector) { continue; }
+                    normalizedSelectors.push(normalizedSelector);
+                }
+
+                if (normalizedSelectors.length === 0) { return []; }
+
+                var uniqueSelectors = [];
+                var seenSelectors = Object.create(null);
+                for (var uniqueIndex = 0; uniqueIndex < normalizedSelectors.length; uniqueIndex += 1) {
+                    var normalizedSelector = normalizedSelectors[uniqueIndex];
+                    if (seenSelectors[normalizedSelector]) { continue; }
+                    seenSelectors[normalizedSelector] = true;
+                    uniqueSelectors.push(normalizedSelector);
+                }
+
+                return groupedDisplayNoneCSS(uniqueSelectors);
+            };
+
+            var domainMatches = function(ruleDomain) {
+                if (typeof ruleDomain !== "string") { return false; }
+                var normalizedRuleDomain = ruleDomain.trim().toLowerCase();
+                if (!normalizedRuleDomain) { return false; }
+                if (normalizedRuleDomain.startsWith("*.")) {
+                    var suffix = normalizedRuleDomain.slice(2);
+                    return !!suffix && currentHost.length > suffix.length && currentHost.endsWith("." + suffix);
+                }
+                return currentHost === normalizedRuleDomain;
+            };
+
+            var frameMatches = function(frameScope) {
+                if (frameScope === "mainFrameOnly") {
+                    return window.top === window.self;
+                }
+                if (frameScope === "subframesOnly") {
+                    return window.top !== window.self;
+                }
+                return true;
+            };
+
+            for (var index = 0; index < rules.length; index += 1) {
+                var rule = rules[index];
+                if (!frameMatches(rule.frameScope)) { continue; }
+
+                if (rule.urlFilterPattern) {
+                    try {
+                        if (!(new RegExp(rule.urlFilterPattern)).test(locationHref)) { continue; }
+                    } catch (error) {
+                        continue;
+                    }
+                }
+
+                var ifDomainList = Array.isArray(rule.ifDomainList) ? rule.ifDomainList : [];
+                var unlessDomainList = Array.isArray(rule.unlessDomainList) ? rule.unlessDomainList : [];
+
+                if (ifDomainList.length > 0) {
+                    if (!currentHost) { continue; }
+                    if (!ifDomainList.some(domainMatches)) { continue; }
+                }
+                if (currentHost && unlessDomainList.some(domainMatches)) { continue; }
+
+                var hiddenSelectors = Array.isArray(rule.hiddenSelectors) ? rule.hiddenSelectors : [];
+                for (var hiddenSelectorIndex = 0; hiddenSelectorIndex < hiddenSelectors.length; hiddenSelectorIndex += 1) {
+                    collectedSelectors.push(hiddenSelectors[hiddenSelectorIndex]);
+                }
+            }
+
+            if (collectedSelectors.length === 0) { return; }
+            var compactedCSS = compactHiddenSelectors(collectedSelectors);
+
+            var styleId = "\(styleIDLiteral)";
+            var root = document.head || document.documentElement;
+            if (!root) { return; }
+            var style = document.getElementById(styleId);
+            if (!style) {
+                style = document.createElement('style');
+                style.id = styleId;
+                root.appendChild(style);
+            }
+            style.textContent = compactedCSS.join("\\n");
         })();
         """
     }
@@ -2255,6 +2676,12 @@ fileprivate struct AndroidDocumentStartRuleRegistration {
     let styleID: String
 }
 
+fileprivate struct AndroidDocumentStartRuleBatch {
+    let allowedOriginRules: [String]
+    var rules: [AndroidCosmeticRule]
+    var approximateCharacterCount: Int
+}
+
 final class AndroidContentBlockerController {
     let config: WebEngineConfiguration
     // Think of persistent rules as a baseline installed once per WebView and reused
@@ -2295,8 +2722,18 @@ final class AndroidContentBlockerController {
         let desiredNavigationRules = desiredNavigationRules(for: pageURL, isWhitelisted: isWhitelisted)
         let cosmeticQueryMilliseconds = currentMilliseconds() - cosmeticQueryStartedAt
 
+        let persistentChanged = desiredPersistentRules != installedPersistentRules
+        let navigationChanged = desiredNavigationRules != installedNavigationRules
+
         let persistentPlanStartedAt = currentMilliseconds()
-        let persistentPlan = WebEngine.androidCosmeticInjectionPlan(
+        var persistentPlan = AndroidCosmeticInjectionPlan()
+        if persistentChanged {
+            persistentPlan.documentStartRules = WebEngine.androidDocumentStartCosmeticRules(
+                rules: desiredPersistentRules,
+                isDocumentStartSupported: documentStartSupported
+            )
+        }
+        persistentPlan.lifecycleCSS = WebEngine.androidLifecycleCosmeticCSS(
             rules: desiredPersistentRules,
             pageURL: pageURL,
             isDocumentStartSupported: documentStartSupported
@@ -2306,7 +2743,14 @@ final class AndroidContentBlockerController {
         let persistentPlanMilliseconds = currentMilliseconds() - persistentPlanStartedAt
 
         let navigationPlanStartedAt = currentMilliseconds()
-        let navigationPlan = WebEngine.androidCosmeticInjectionPlan(
+        var navigationPlan = AndroidCosmeticInjectionPlan()
+        if navigationChanged {
+            navigationPlan.documentStartRules = WebEngine.androidDocumentStartCosmeticRules(
+                rules: desiredNavigationRules,
+                isDocumentStartSupported: documentStartSupported
+            )
+        }
+        navigationPlan.lifecycleCSS = WebEngine.androidLifecycleCosmeticCSS(
             rules: desiredNavigationRules,
             pageURL: pageURL,
             isDocumentStartSupported: documentStartSupported
@@ -2317,9 +2761,6 @@ final class AndroidContentBlockerController {
 
         persistentLifecycleCosmeticCSS = persistentPlan.lifecycleCSS
         navigationLifecycleCosmeticCSS = navigationPlan.lifecycleCSS
-
-        let persistentChanged = desiredPersistentRules != installedPersistentRules
-        let navigationChanged = desiredNavigationRules != installedNavigationRules
 
         let persistentRegisterStartedAt = currentMilliseconds()
         var removedPersistentHandlerCount = 0
@@ -2371,7 +2812,7 @@ final class AndroidContentBlockerController {
 
         androidPreparedCosmeticPageURL = pageURL.absoluteString
         logger.info(
-            "Android blocker prepare url=\(pageURL.absoluteString) totalMs=\(formatMilliseconds(currentMilliseconds() - prepareStartedAt)) whitelisted=\(isWhitelisted) cosmeticQueryMs=\(formatMilliseconds(cosmeticQueryMilliseconds)) documentStartSupported=\(documentStartSupported) persistentChanged=\(persistentChanged) persistentRuleCount=\(desiredPersistentRules.count) persistentCSSCount=\(cssEntryCount(in: desiredPersistentRules)) persistentPlanMs=\(formatMilliseconds(persistentPlanMilliseconds)) persistentRegisterMs=\(formatMilliseconds(persistentRegisterMilliseconds)) removedPersistentHandlers=\(removedPersistentHandlerCount) registeredPersistentHandlers=\(registeredPersistentHandlerCount) navigationChanged=\(navigationChanged) navigationRuleCount=\(desiredNavigationRules.count) navigationCSSCount=\(cssEntryCount(in: desiredNavigationRules)) navigationPlanMs=\(formatMilliseconds(navigationPlanMilliseconds)) navigationRegisterMs=\(formatMilliseconds(navigationRegisterMilliseconds)) removedNavigationHandlers=\(removedNavigationHandlerCount) registeredNavigationHandlers=\(registeredNavigationHandlerCount)"
+            "Android blocker prepare url=\(pageURL.absoluteString) totalMs=\(formatMilliseconds(currentMilliseconds() - prepareStartedAt)) whitelisted=\(isWhitelisted) cosmeticQueryMs=\(formatMilliseconds(cosmeticQueryMilliseconds)) documentStartSupported=\(documentStartSupported) persistentChanged=\(persistentChanged) persistentRuleCount=\(desiredPersistentRules.count) persistentSelectorCount=\(selectorEntryCount(in: desiredPersistentRules)) persistentPlanMs=\(formatMilliseconds(persistentPlanMilliseconds)) persistentRegisterMs=\(formatMilliseconds(persistentRegisterMilliseconds)) removedPersistentHandlers=\(removedPersistentHandlerCount) registeredPersistentHandlers=\(registeredPersistentHandlerCount) navigationChanged=\(navigationChanged) navigationRuleCount=\(desiredNavigationRules.count) navigationSelectorCount=\(selectorEntryCount(in: desiredNavigationRules)) navigationPlanMs=\(formatMilliseconds(navigationPlanMilliseconds)) navigationRegisterMs=\(formatMilliseconds(navigationRegisterMilliseconds)) removedNavigationHandlers=\(removedNavigationHandlerCount) registeredNavigationHandlers=\(registeredNavigationHandlerCount)"
         )
     }
 
@@ -2398,19 +2839,19 @@ final class AndroidContentBlockerController {
             logger.info("Falling back to late Android cosmetic injection for \(pageURL.absoluteString)")
         }
 
-        let persistentFuturePlan = WebEngine.androidCosmeticInjectionPlan(
-            rules: desiredPersistentRules,
-            pageURL: pageURL,
-            isDocumentStartSupported: documentStartSupported
-        ) { message in
-            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        var persistentFuturePlan = AndroidCosmeticInjectionPlan()
+        if persistentChanged {
+            persistentFuturePlan.documentStartRules = WebEngine.androidDocumentStartCosmeticRules(
+                rules: desiredPersistentRules,
+                isDocumentStartSupported: documentStartSupported
+            )
         }
-        let navigationFuturePlan = WebEngine.androidCosmeticInjectionPlan(
-            rules: desiredNavigationRules,
-            pageURL: pageURL,
-            isDocumentStartSupported: documentStartSupported
-        ) { message in
-            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        var navigationFuturePlan = AndroidCosmeticInjectionPlan()
+        if navigationChanged {
+            navigationFuturePlan.documentStartRules = WebEngine.androidDocumentStartCosmeticRules(
+                rules: desiredNavigationRules,
+                isDocumentStartSupported: documentStartSupported
+            )
         }
         let persistentFallbackPlan = WebEngine.androidRedirectFallbackCosmeticPlan(
             rules: desiredPersistentRules,
@@ -2562,11 +3003,12 @@ final class AndroidContentBlockerController {
     ) -> AndroidDocumentStartPlanRegistration {
         var handlers: [ScriptHandler] = []
         var styleIDs: [String] = []
+        let batchedRules = batchedDocumentStartRules(plan.documentStartRules)
 
-        for (index, rule) in plan.documentStartRules.enumerated() {
+        for (index, batch) in batchedRules.enumerated() {
             let registerStartedAt = currentMilliseconds()
-            if let registration = registerAndroidDocumentStartCosmeticRule(
-                rule,
+            if let registration = registerAndroidDocumentStartCosmeticRuleBatch(
+                batch,
                 index: index,
                 styleIDPrefix: styleIDPrefix,
                 for: pageURL,
@@ -2577,7 +3019,7 @@ final class AndroidContentBlockerController {
             }
             let registerMilliseconds = currentMilliseconds() - registerStartedAt
             logger.info(
-                "Android blocker register url=\(pageURL.absoluteString) prefix=\(styleIDPrefix) index=\(index) cssCount=\(rule.css.count) cssChars=\(cssCharacterCountInCSSRules(rule.css)) allowedOrigins=\(rule.allowedOriginRules.count) ms=\(formatMilliseconds(registerMilliseconds))"
+                "Android blocker register url=\(pageURL.absoluteString) prefix=\(styleIDPrefix) index=\(index) ruleCount=\(batch.rules.count) selectorCount=\(selectorEntryCount(in: batch.rules)) selectorChars=\(selectorCharacterCountInRules(batch.rules)) allowedOrigins=\(batch.allowedOriginRules.count) ms=\(formatMilliseconds(registerMilliseconds))"
             )
         }
 
@@ -2587,24 +3029,22 @@ final class AndroidContentBlockerController {
         )
     }
 
-    private func registerAndroidDocumentStartCosmeticRule(
-        _ rule: AndroidCosmeticRule,
+    private func registerAndroidDocumentStartCosmeticRuleBatch(
+        _ batch: AndroidDocumentStartRuleBatch,
         index: Int,
         styleIDPrefix: String,
         for pageURL: URL,
         in view: PlatformWebView
     ) -> AndroidDocumentStartRuleRegistration? {
         let styleID = "\(styleIDPrefix)_\(index)"
-        guard let script = WebEngine.androidContentBlockerStyleInjectionScript(
-            cssRules: rule.css,
-            styleID: styleID,
-            frameScope: rule.frameScope,
-            urlFilterPattern: rule.urlFilterPattern
+        guard let script = WebEngine.androidContentBlockerBatchedStyleInjectionScript(
+            rules: batch.rules,
+            styleID: styleID
         ) else {
             return nil
         }
         let allowedOriginRules: kotlin.collections.MutableSet<String> = kotlin.collections.HashSet()
-        for allowedOriginRule in rule.allowedOriginRules {
+        for allowedOriginRule in batch.allowedOriginRules {
             allowedOriginRules.add(allowedOriginRule)
         }
 
@@ -2621,6 +3061,38 @@ final class AndroidContentBlockerController {
             handler: WebViewCompat.addDocumentStartJavaScript(view, script, allowedOriginRules),
             styleID: styleID
         )
+    }
+
+    private func batchedDocumentStartRules(
+        _ rules: [AndroidCosmeticRule]
+    ) -> [AndroidDocumentStartRuleBatch] {
+        let maximumRulesPerBatch = 128
+        let maximumApproximateCharactersPerBatch = 24_000
+
+        var batches: [AndroidDocumentStartRuleBatch] = []
+        batches.reserveCapacity((rules.count / maximumRulesPerBatch) + 1)
+
+        for rule in rules {
+            let approximateCharacterCount = approximateDocumentStartRuleCharacterCount(rule)
+            if var lastBatch = batches.last,
+               lastBatch.allowedOriginRules == rule.allowedOriginRules,
+               lastBatch.rules.count < maximumRulesPerBatch,
+               lastBatch.approximateCharacterCount + approximateCharacterCount <= maximumApproximateCharactersPerBatch {
+                lastBatch.rules.append(rule)
+                lastBatch.approximateCharacterCount += approximateCharacterCount
+                batches[batches.count - 1] = lastBatch
+            } else {
+                batches.append(
+                    AndroidDocumentStartRuleBatch(
+                        allowedOriginRules: rule.allowedOriginRules,
+                        rules: [rule],
+                        approximateCharacterCount: approximateCharacterCount
+                    )
+                )
+            }
+        }
+
+        return batches
     }
 
     private func clearInsertedDocumentStartStyles(in view: PlatformWebView) {
@@ -2667,20 +3139,40 @@ final class AndroidContentBlockerController {
         String((value * 10.0).rounded() / 10.0)
     }
 
-    private func cssEntryCount(in rules: [AndroidCosmeticRule]) -> Int {
+    private func selectorEntryCount(in rules: [AndroidCosmeticRule]) -> Int {
         var count = 0
         for rule in rules {
-            count += rule.css.count
+            count += rule.hiddenSelectors.count
         }
         return count
     }
 
-    private func cssCharacterCountInCSSRules(_ cssRules: [String]) -> Int {
+    private func selectorCharacterCountInRules(_ rules: [AndroidCosmeticRule]) -> Int {
         var count = 0
-        for cssRule in cssRules {
-            count += cssRule.count
+        for rule in rules {
+            count += selectorCharacterCountInSelectorEntries(rule.hiddenSelectors)
         }
         return count
+    }
+
+    private func selectorCharacterCountInSelectorEntries(_ hiddenSelectors: [String]) -> Int {
+        var count = 0
+        for hiddenSelector in hiddenSelectors {
+            count += hiddenSelector.count
+        }
+        return count
+    }
+
+    private func approximateDocumentStartRuleCharacterCount(_ rule: AndroidCosmeticRule) -> Int {
+        var count = selectorCharacterCountInSelectorEntries(rule.hiddenSelectors)
+        count += rule.urlFilterPattern?.count ?? 0
+        for domain in rule.ifDomainList {
+            count += domain.count
+        }
+        for domain in rule.unlessDomainList {
+            count += domain.count
+        }
+        return count + 64
     }
 }
 
@@ -3251,7 +3743,9 @@ public extension SkipWebUIDelegate {
     public var schemeHandlers: [String: URLSchemeHandler]
     public var uiDelegate: (any SkipWebUIDelegate)?
     public var navigationDelegate: (any SkipWebNavigationDelegate)?
+    /// Optional content-blocker configuration applied to web views created from this configuration.
     public var contentBlockers: WebContentBlockerConfiguration?
+    /// The latest errors produced while preparing or installing content blockers.
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
 
     #if SKIP
@@ -3321,7 +3815,7 @@ public extension SkipWebUIDelegate {
         return copy
     }
 
-    /// Clear any persisted compiled iOS content-blocker rule lists so the next install recompiles from source.
+    /// Clears the persisted iOS content-blocker cache so the next setup recompiles from source.
     ///
     /// The cache is shared across `WebEngineConfiguration` instances. On non-Apple platforms this is a no-op.
     @MainActor public static func clearContentBlockerCache() throws {
@@ -3330,7 +3824,7 @@ public extension SkipWebUIDelegate {
         #endif
     }
 
-    /// Prepare any configured content blockers and populate `contentBlockerSetupErrors`.
+    /// Prepares any configured content blockers and populates `contentBlockerSetupErrors`.
     ///
     /// On Apple platforms this compiles or loads persisted rule lists so later web view creation
     /// can attach them without the initial compile cost. On other platforms this is a no-op.

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -803,6 +803,7 @@ extension WebCookie {
     }
     private var observers: [NSKeyValueObservation] = []
     private var profileSetupError: WebProfileError?
+    private var iosContentBlockerSetupTask: Task<[WebContentBlockerError], Never>?
     #else
     private var profileSetupError: WebProfileError?
     private var androidProfileCookieManager: android.webkit.CookieManager?
@@ -824,10 +825,8 @@ extension WebCookie {
         #if !SKIP
         if let webView {
             self.webView = webView
-            self.contentBlockerSetupErrors = configuration.installContentBlockers(into: webView.configuration.userContentController)
         } else {
-            self.webView = WKWebView(frame: .zero, configuration: configuration.webViewConfiguration)
-            self.contentBlockerSetupErrors = configuration.contentBlockerSetupErrors
+            self.webView = WKWebView(frame: .zero, configuration: configuration.makeBaseWebViewConfiguration())
         }
         if case .named = configuration.profile, configuration.profile.normalizedNamedIdentifier == nil {
             self.profileSetupError = .invalidProfileName
@@ -850,16 +849,28 @@ extension WebCookie {
         }
         self.webView.webViewClient = androidInternalWebViewClient
         #endif
+
+        super.init()
+
+        #if !SKIP
+        scheduleIOSContentBlockerSetupIfNeeded()
+        #endif
     }
 
     public func reload() {
         if profileSetupError != nil {
             return
         }
+        #if !SKIP
+        runAfterIOSContentBlockerSetupIfNeeded { [webView] in
+            webView.reload()
+        }
+        #else
         #if SKIP
         prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: url)
         #endif
         webView.reload()
+        #endif
     }
 
     public func stopLoading() {
@@ -884,20 +895,32 @@ extension WebCookie {
         if profileSetupError != nil {
             return
         }
+        #if !SKIP
+        runAfterIOSContentBlockerSetupIfNeeded { [webView] in
+            webView.goBack()
+        }
+        #else
         #if SKIP
         prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: -1))
         #endif
         webView.goBack()
+        #endif
     }
 
     public func goForward() {
         if profileSetupError != nil {
             return
         }
+        #if !SKIP
+        runAfterIOSContentBlockerSetupIfNeeded { [webView] in
+            webView.goForward()
+        }
+        #else
         #if SKIP
         prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: 1))
         #endif
         webView.goForward()
+        #endif
     }
 
     /// Preferred URL accessor for parity with `WKWebView.url`.
@@ -995,6 +1018,17 @@ extension WebCookie {
         }
     }
 
+    public func awaitContentBlockerSetup() async -> [WebContentBlockerError] {
+        #if !SKIP
+        if let iosContentBlockerSetupTask {
+            let errors = await iosContentBlockerSetupTask.value
+            contentBlockerSetupErrors = errors
+            return errors
+        }
+        #endif
+        return contentBlockerSetupErrors
+    }
+
     #if SKIP
     struct AndroidProfileResources {
         let cookieManager: android.webkit.CookieManager?
@@ -1076,6 +1110,33 @@ extension WebCookie {
 
     private func androidWebStorage() -> android.webkit.WebStorage {
         androidProfileWebStorage ?? android.webkit.WebStorage.getInstance()
+    }
+    #else
+    private func scheduleIOSContentBlockerSetupIfNeeded() {
+        guard iosContentBlockerSetupTask == nil else {
+            return
+        }
+        guard configuration.contentBlockers?.iOSRuleListPaths.isEmpty == false else {
+            return
+        }
+
+        let userContentController = webView.configuration.userContentController
+        iosContentBlockerSetupTask = Task { @MainActor [configuration, weak self] in
+            let errors = await configuration.installContentBlockers(into: userContentController)
+            self?.contentBlockerSetupErrors = errors
+            return errors
+        }
+    }
+
+    private func runAfterIOSContentBlockerSetupIfNeeded(_ operation: @escaping @MainActor () -> Void) {
+        if let iosContentBlockerSetupTask {
+            Task { @MainActor in
+                _ = await iosContentBlockerSetupTask.value
+                operation()
+            }
+        } else {
+            operation()
+        }
     }
     #endif
 
@@ -1359,10 +1420,13 @@ extension WebCookie {
         let historyUrl: String? = nil // the URL to use as the history entry. If null defaults to 'about:blank'. If non-null, this must be a valid URL.
         webView.loadDataWithBaseURL(baseUrl, htmlContent, mimeType, encoding, historyUrl)
         #else
-        refreshMessageHandlers()
-        //try await awaitPageLoaded {
-        webView.load(Data(html.utf8), mimeType: mimeType, characterEncodingName: encoding, baseURL: baseURL ?? URL(string: "about:blank")!)
-        //}
+        runAfterIOSContentBlockerSetupIfNeeded { [weak self] in
+            guard let self else {
+                return
+            }
+            self.refreshMessageHandlers()
+            self.webView.load(Data(html.utf8), mimeType: mimeType, characterEncodingName: encoding, baseURL: baseURL ?? URL(string: "about:blank")!)
+        }
         #endif
     }
 
@@ -1373,6 +1437,8 @@ extension WebCookie {
         logger.info("load URL=\(urlString) webView: \(self.description)")
         #if SKIP
         androidContentBlockerController.prepare(for: url, in: webView)
+        #else
+        _ = await awaitContentBlockerSetup()
         #endif
         try await awaitPageLoaded {
             #if SKIP
@@ -2831,8 +2897,15 @@ public extension SkipWebUIDelegate {
     }
 
     #if !SKIP
-    /// Create a `WebViewConfiguration` from the properties of this configuration.
-    @MainActor public var webViewConfiguration: WebViewConfiguration {
+    /// Create a `WebViewConfiguration` from the properties of this configuration and
+    /// asynchronously install any configured iOS content blockers.
+    @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration {
+        let configuration = makeBaseWebViewConfiguration()
+        _ = await installContentBlockers(into: configuration.userContentController)
+        return configuration
+    }
+
+    @MainActor func makeBaseWebViewConfiguration() -> WebViewConfiguration {
         let configuration = WebViewConfiguration()
         configuration.websiteDataStore = webKitWebsiteDataStore
 
@@ -2849,21 +2922,18 @@ public extension SkipWebUIDelegate {
             configuration.setURLSchemeHandler(schemeHandlerObject, forURLScheme: schemeName)
         }
         #endif
-
-        _ = installContentBlockers(into: configuration.userContentController)
-
         return configuration
     }
 
     @MainActor
     @discardableResult
-    func installContentBlockers(into userContentController: WKUserContentController) -> [WebContentBlockerError] {
+    public func installContentBlockers(into userContentController: WKUserContentController) async -> [WebContentBlockerError] {
         contentBlockerSetupErrors = []
         guard let contentBlockers, !contentBlockers.iOSRuleListPaths.isEmpty else {
             return []
         }
 
-        let prepared = WebContentBlockerStore.prepareRuleLists(from: contentBlockers.iOSRuleListPaths)
+        let prepared = await WebContentBlockerStore.prepareRuleLists(from: contentBlockers.iOSRuleListPaths)
         contentBlockerSetupErrors = prepared.errors
         for ruleList in prepared.ruleLists {
             userContentController.add(ruleList)
@@ -2970,7 +3040,7 @@ fileprivate enum WebContentBlockerStore {
     private static let storeDirectoryName = "RuleListStore"
     private static let metadataVersion = 1
 
-    static func prepareRuleLists(from sourcePaths: [String]) -> PreparedContentBlockerRuleLists {
+    static func prepareRuleLists(from sourcePaths: [String]) async -> PreparedContentBlockerRuleLists {
         var ruleLists: [WKContentRuleList] = []
         var errors: [WebContentBlockerError] = []
 
@@ -3009,13 +3079,13 @@ fileprivate enum WebContentBlockerStore {
             nextIdentifiersBySourcePath[sourcePath] = identifier
             staleIdentifiers.remove(identifier)
 
-            if let cachedRuleList = lookupRuleList(identifier: identifier, in: store, errors: &errors) {
+            if let cachedRuleList = await lookupRuleList(identifier: identifier, in: store, errors: &errors) {
                 ruleLists.append(cachedRuleList)
                 diagnostics.cacheHitIdentifiers.append(identifier)
                 continue
             }
 
-            if let compiledRuleList = compileRuleList(identifier: identifier, content: content, sourcePath: sourcePath, in: store, errors: &errors) {
+            if let compiledRuleList = await compileRuleList(identifier: identifier, content: content, sourcePath: sourcePath, in: store, errors: &errors) {
                 ruleLists.append(compiledRuleList)
                 diagnostics.compiledIdentifiers.append(identifier)
             }
@@ -3023,7 +3093,7 @@ fileprivate enum WebContentBlockerStore {
 
         let activeIdentifiers = Set(nextIdentifiersBySourcePath.values)
         for staleIdentifier in staleIdentifiers.subtracting(activeIdentifiers) {
-            removeRuleList(identifier: staleIdentifier, from: store, errors: &errors)
+            await removeRuleList(identifier: staleIdentifier, from: store, errors: &errors)
         }
 
         metadata.identifiersBySourcePath = nextIdentifiersBySourcePath
@@ -3130,17 +3200,20 @@ fileprivate enum WebContentBlockerStore {
         }
     }
 
-    private static func lookupRuleList(identifier: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) -> WKContentRuleList? {
-        switch awaitCallback(description: "lookup \(identifier)") { completion in
-            store.lookUpContentRuleList(forIdentifier: identifier) { ruleList, error in
-                completion(ruleList, error)
+    private static func lookupRuleList(identifier: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) async -> WKContentRuleList? {
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                store.lookUpContentRuleList(forIdentifier: identifier) { ruleList, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ruleList)
+                    }
+                }
             }
-        } {
-        case .success(let ruleList):
-            return ruleList
-        case .failure(let error as WebContentBlockerError):
+        } catch let error as WebContentBlockerError {
             errors.append(error)
-        case .failure(let error):
+        } catch {
             let nsError = error as NSError
             if nsError.domain == WKErrorDomain,
                nsError.code == WKError.Code.contentRuleListStoreLookUpFailed.rawValue {
@@ -3151,33 +3224,40 @@ fileprivate enum WebContentBlockerStore {
         return nil
     }
 
-    private static func compileRuleList(identifier: String, content: String, sourcePath: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) -> WKContentRuleList? {
-        switch awaitCallback(description: "compile \(sourcePath)") { completion in
-            store.compileContentRuleList(forIdentifier: identifier, encodedContentRuleList: content) { ruleList, error in
-                completion(ruleList, error)
+    private static func compileRuleList(identifier: String, content: String, sourcePath: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) async -> WKContentRuleList? {
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                store.compileContentRuleList(forIdentifier: identifier, encodedContentRuleList: content) { ruleList, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ruleList)
+                    }
+                }
             }
-        } {
-        case .success(let ruleList):
-            return ruleList
-        case .failure(let error as WebContentBlockerError):
+        } catch let error as WebContentBlockerError {
             errors.append(error)
-        case .failure(let error):
+        } catch {
             errors.append(.compilationFailed(path: sourcePath, description: error.localizedDescription))
         }
         return nil
     }
 
-    private static func removeRuleList(identifier: String, from store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) {
-        switch awaitVoidCallback(description: "remove \(identifier)") { completion in
-            store.removeContentRuleList(forIdentifier: identifier) { error in
-                completion(error)
+    private static func removeRuleList(identifier: String, from store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) async {
+        do {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                store.removeContentRuleList(forIdentifier: identifier) { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume(returning: ())
+                    }
+                }
             }
-        } {
-        case .success:
             diagnostics.prunedIdentifiers.append(identifier)
-        case .failure(let error as WebContentBlockerError):
+        } catch let error as WebContentBlockerError {
             errors.append(error)
-        case .failure(let error):
+        } catch {
             let nsError = error as NSError
             // Failing to delete a stale compiled rule list should not prevent the current rule set from loading.
             if nsError.domain == WKErrorDomain,
@@ -3186,95 +3266,6 @@ fileprivate enum WebContentBlockerStore {
             }
             errors.append(.staleRuleRemovalFailed(identifier: identifier, description: error.localizedDescription))
         }
-    }
-
-    private static func awaitCallback<T>(
-        description: String,
-        operation: (@escaping (T?, Error?) -> Void) -> Void
-    ) -> Result<T?, Error> {
-        let lock = NSLock()
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<T?, Error>?
-        operation { value, error in
-            let callbackResult: Result<T?, Error>
-            if let error {
-                callbackResult = .failure(error)
-            } else {
-                callbackResult = .success(value)
-            }
-            lock.lock()
-            result = callbackResult
-            lock.unlock()
-            semaphore.signal()
-        }
-
-        let deadline = Date().addingTimeInterval(contentBlockerCallbackTimeout)
-        while deadline.timeIntervalSinceNow > 0 {
-            if semaphore.wait(timeout: .now()) == .success {
-                lock.lock()
-                defer { lock.unlock() }
-                return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
-            }
-
-            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-            RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.01))
-        }
-
-        lock.lock()
-        defer { lock.unlock() }
-        return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
-    }
-
-    private static func awaitVoidCallback(
-        description: String,
-        operation: (@escaping (Error?) -> Void) -> Void
-    ) -> Result<Void, Error> {
-        let lock = NSLock()
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Result<Void, Error>?
-        operation { error in
-            let callbackResult: Result<Void, Error>
-            if let error {
-                callbackResult = .failure(error)
-            } else {
-                callbackResult = .success(())
-            }
-            lock.lock()
-            result = callbackResult
-            lock.unlock()
-            semaphore.signal()
-        }
-
-        let deadline = Date().addingTimeInterval(contentBlockerCallbackTimeout)
-        while deadline.timeIntervalSinceNow > 0 {
-            if semaphore.wait(timeout: .now()) == .success {
-                lock.lock()
-                defer { lock.unlock() }
-                return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
-            }
-
-            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
-            RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.01))
-        }
-
-        lock.lock()
-        defer { lock.unlock() }
-        return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
-    }
-
-    private static var contentBlockerCallbackTimeout: TimeInterval {
-        let environment = ProcessInfo.processInfo.environment
-        if let rawValue = environment["SKIPWEB_CONTENT_BLOCKER_TIMEOUT"],
-           let timeout = TimeInterval(rawValue),
-           timeout > 0 {
-            return timeout
-        }
-
-        if environment["GITHUB_ACTIONS"] == "true" || environment["CI"] == "true" {
-            return 60.0
-        }
-
-        return 10.0
     }
 
     private static func hexString<D: Digest>(_ digest: D) -> String {

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -10,6 +10,7 @@ import CryptoKit
 #else
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import androidx.webkit.WebResourceRequestCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import kotlin.coroutines.suspendCoroutine
@@ -146,6 +147,133 @@ public enum WebProfileError: Error, Equatable {
     case unsupportedOnAndroid
     case invalidProfileName
     case profileSetupFailed
+}
+
+public struct WebContentBlockerConfiguration {
+    public var iOSRuleListPaths: [String]
+    public var androidRequestBlocker: (any AndroidRequestBlocker)?
+    public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
+
+    public init(
+        iOSRuleListPaths: [String] = [],
+        androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
+        androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
+    ) {
+        self.iOSRuleListPaths = iOSRuleListPaths
+        self.androidRequestBlocker = androidRequestBlocker
+        self.androidCosmeticBlocker = androidCosmeticBlocker
+    }
+}
+
+public enum AndroidRequestBlockDecision: Sendable {
+    case allow
+    case block
+}
+
+public enum AndroidResourceTypeHint: String, CaseIterable, Hashable, Sendable {
+    case document
+    case subdocument
+    case stylesheet
+    case script
+    case image
+    case font
+    case media
+    case xhr
+    case fetch
+    case websocket
+    case other
+}
+
+public struct AndroidBlockableRequest: Equatable, Sendable {
+    public var url: URL
+    public var mainDocumentURL: URL?
+    public var method: String
+    public var headers: [String: String]
+    public var isForMainFrame: Bool
+    public var hasGesture: Bool
+    public var isRedirect: Bool?
+    public var resourceTypeHint: AndroidResourceTypeHint?
+
+    public init(
+        url: URL,
+        mainDocumentURL: URL? = nil,
+        method: String,
+        headers: [String: String] = [:],
+        isForMainFrame: Bool,
+        hasGesture: Bool,
+        isRedirect: Bool? = nil,
+        resourceTypeHint: AndroidResourceTypeHint? = nil
+    ) {
+        self.url = url
+        self.mainDocumentURL = mainDocumentURL
+        self.method = method
+        self.headers = headers
+        self.isForMainFrame = isForMainFrame
+        self.hasGesture = hasGesture
+        self.isRedirect = isRedirect
+        self.resourceTypeHint = resourceTypeHint
+    }
+}
+
+public protocol AndroidRequestBlocker {
+    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
+}
+
+public struct AndroidPageContext: Equatable, Sendable {
+    public var url: URL
+    public var host: String?
+
+    public init(url: URL, host: String? = nil) {
+        self.url = url
+        self.host = host ?? url.host
+    }
+}
+
+public struct AndroidCosmeticPayload: Equatable, Sendable {
+    public var css: [String]
+
+    public init(css: [String] = []) {
+        self.css = css
+    }
+}
+
+public protocol AndroidCosmeticBlocker {
+    func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload?
+}
+
+public enum WebContentBlockerError: Error, Equatable, LocalizedError {
+    case storeUnavailable(String)
+    case fileReadFailed(path: String, description: String)
+    case fileEncodingFailed(path: String)
+    case cacheLookupFailed(identifier: String, description: String)
+    case compilationFailed(path: String, description: String)
+    case metadataReadFailed(String)
+    case metadataWriteFailed(String)
+    case staleRuleRemovalFailed(identifier: String, description: String)
+    case operationTimedOut(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .storeUnavailable(let description):
+            return "Content blocker store unavailable: \(description)"
+        case .fileReadFailed(let path, let description):
+            return "Failed to read content blocker file at \(path): \(description)"
+        case .fileEncodingFailed(let path):
+            return "Content blocker file is not valid UTF-8: \(path)"
+        case .cacheLookupFailed(let identifier, let description):
+            return "Failed to look up compiled content blocker \(identifier): \(description)"
+        case .compilationFailed(let path, let description):
+            return "Failed to compile content blocker file at \(path): \(description)"
+        case .metadataReadFailed(let description):
+            return "Failed to read content blocker metadata: \(description)"
+        case .metadataWriteFailed(let description):
+            return "Failed to write content blocker metadata: \(description)"
+        case .staleRuleRemovalFailed(let identifier, let description):
+            return "Failed to remove stale compiled content blocker \(identifier): \(description)"
+        case .operationTimedOut(let description):
+            return "Timed out while preparing content blockers: \(description)"
+        }
+    }
 }
 
 public enum WebSiteDataType: String, CaseIterable, Hashable, Sendable {
@@ -521,6 +649,7 @@ extension WebCookie {
 @MainActor public class WebEngine : WebObjectBase {
     public let configuration: WebEngineConfiguration
     public let webView: PlatformWebView
+    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
     #if !SKIP
     public override var description: String {
         "WebEngine: \(webView)"
@@ -541,7 +670,13 @@ extension WebCookie {
         self.configuration = configuration
 
         #if !SKIP
-        self.webView = webView ?? WKWebView(frame: .zero, configuration: configuration.webViewConfiguration)
+        if let webView {
+            self.webView = webView
+            self.contentBlockerSetupErrors = configuration.installContentBlockers(into: webView.configuration.userContentController)
+        } else {
+            self.webView = WKWebView(frame: .zero, configuration: configuration.webViewConfiguration)
+            self.contentBlockerSetupErrors = configuration.contentBlockerSetupErrors
+        }
         if case .named = configuration.profile, configuration.profile.normalizedNamedIdentifier == nil {
             self.profileSetupError = .invalidProfileName
         }
@@ -1098,6 +1233,174 @@ extension WebCookie {
     }
     #endif
 
+    #if SKIP
+    fileprivate static func androidRequestHeaders(from request: android.webkit.WebResourceRequest) -> [String: String] {
+        var headers: [String: String] = [:]
+        for (key, value) in request.requestHeaders {
+            headers[String(describing: key)] = String(describing: value)
+        }
+        return headers
+    }
+
+    fileprivate static func androidMainDocumentURL(
+        for request: android.webkit.WebResourceRequest,
+        requestURL: URL,
+        headers: [String: String]
+    ) -> URL? {
+        if request.isForMainFrame {
+            return requestURL
+        }
+
+        // `shouldInterceptRequest` runs off the UI thread on Android, so avoid touching
+        // the backing WebView for its current URL here.
+        let lowercaseHeaders = Dictionary(uniqueKeysWithValues: headers.map { ($0.key.lowercased(), $0.value) })
+        if let referer = lowercaseHeaders["referer"], let refererURL = URL(string: referer) {
+            return refererURL
+        }
+        if let origin = lowercaseHeaders["origin"], let originURL = URL(string: origin) {
+            return originURL
+        }
+        return nil
+    }
+
+    fileprivate static func androidResourceTypeHint(
+        for request: android.webkit.WebResourceRequest,
+        requestURL: URL,
+        headers: [String: String]
+    ) -> AndroidResourceTypeHint {
+        if request.isForMainFrame {
+            return .document
+        }
+
+        let lowercaseHeaders = Dictionary(uniqueKeysWithValues: headers.map { ($0.key.lowercased(), $0.value.lowercased()) })
+        if let secFetchDest = lowercaseHeaders["sec-fetch-dest"] {
+            switch secFetchDest {
+            case "document":
+                return .document
+            case "iframe", "frame":
+                return .subdocument
+            case "style":
+                return .stylesheet
+            case "script":
+                return .script
+            case "image":
+                return .image
+            case "font":
+                return .font
+            case "audio", "video":
+                return .media
+            case "empty":
+                if let requestedWith = lowercaseHeaders["x-requested-with"], requestedWith == "xmlhttprequest" {
+                    return .xhr
+                }
+                return .fetch
+            default:
+                break
+            }
+        }
+
+        if let accept = lowercaseHeaders["accept"] {
+            if accept.contains("text/css") {
+                return .stylesheet
+            }
+            if accept.contains("javascript") || accept.contains("ecmascript") {
+                return .script
+            }
+            if accept.contains("image/") {
+                return .image
+            }
+            if accept.contains("font/") {
+                return .font
+            }
+            if accept.contains("video/") || accept.contains("audio/") {
+                return .media
+            }
+            if accept.contains("text/html") {
+                return .subdocument
+            }
+        }
+
+        switch requestURL.pathExtension.lowercased() {
+        case "css":
+            return .stylesheet
+        case "js", "mjs", "cjs":
+            return .script
+        case "png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif":
+            return .image
+        case "woff", "woff2", "ttf", "otf":
+            return .font
+        case "mp4", "webm", "mov", "m4v", "mp3", "wav", "ogg", "m4a":
+            return .media
+        case "html", "htm":
+            return .subdocument
+        default:
+            break
+        }
+
+        return .other
+    }
+
+    fileprivate static func blockedAndroidResponse() -> android.webkit.WebResourceResponse {
+        let responseHeaders: kotlin.collections.Map<String, String> = kotlin.collections.HashMap()
+        return android.webkit.WebResourceResponse(
+            "text/plain",
+            "utf-8",
+            204,
+            "No Content",
+            responseHeaders,
+            "".byteInputStream()
+        )
+    }
+
+    static func androidRedirectFlag(
+        isRedirectFeatureSupported: Bool = WebViewFeature.isFeatureSupported(WebViewFeature.WEB_RESOURCE_REQUEST_IS_REDIRECT),
+        resolveRedirect: () -> Bool
+    ) -> Bool? {
+        guard isRedirectFeatureSupported else {
+            return nil
+        }
+        return resolveRedirect()
+    }
+
+    fileprivate static func androidRequestIsRedirect(_ request: android.webkit.WebResourceRequest) -> Bool? {
+        androidRedirectFlag {
+            WebResourceRequestCompat.isRedirect(request)
+        }
+    }
+
+    fileprivate static func androidContentBlockerStyleInjectionScript(cssPayload: AndroidCosmeticPayload) -> String? {
+        let css = cssPayload.css
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        guard !css.isEmpty else {
+            return nil
+        }
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: [css], options: []),
+            let encoded = String(data: data, encoding: .utf8)
+        else {
+            return nil
+        }
+        let cssLiteral = String(encoded.dropFirst().dropLast())
+        return """
+        (function() {
+            var styleId = "__skipweb_content_blockers";
+            var css = \(cssLiteral);
+            var root = document.head || document.documentElement;
+            if (!root) { return; }
+            var style = document.getElementById(styleId);
+            if (!style) {
+                style = document.createElement('style');
+                style.id = styleId;
+                root.appendChild(style);
+            }
+            style.textContent = css;
+        })();
+        """
+    }
+    #endif
+
     /// Perform the given block and only return once the page has completed loading
     // SKIP @nobridge
     public func awaitPageLoaded(_ block: () -> ()) async throws {
@@ -1254,12 +1557,14 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     /// Notify the host application that WebView content left over from previous page navigations will no longer be drawn.
     override func onPageCommitVisible(view: PlatformWebView, url: String) {
         logger.log("onPageCommitVisible: \(url)")
+        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
         webViewClient.onPageCommitVisible(view, url)
     }
 
     /// Notify the host application that a page has finished loading.
     override func onPageFinished(view: PlatformWebView, url: String) {
         logger.log("onPageFinished: \(url)")
+        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
         for userScript in config.userScripts {
             if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
                 let source = userScript.webKitUserScript.source
@@ -1297,6 +1602,7 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
                 }
             }
         }
+        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
         webViewClient.onPageStarted(view, url, favicon)
     }
 
@@ -1316,6 +1622,21 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     override func onReceivedHttpAuthRequest(view: PlatformWebView, handler: android.webkit.HttpAuthHandler, host: String, realm: String) {
         logger.log("onReceivedHttpAuthRequest: \(handler) \(host) \(realm)")
         webViewClient.onReceivedHttpAuthRequest(view, handler, host, realm)
+    }
+
+    private func injectAndroidContentBlockerCSSIfNeeded(into view: PlatformWebView, url: String) {
+        guard let blocker = config.contentBlockers?.androidCosmeticBlocker,
+              let pageURL = URL(string: url),
+              let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
+                  cssPayload: blocker.cosmetics(for: AndroidPageContext(url: pageURL)) ?? AndroidCosmeticPayload()
+              )
+        else {
+            return
+        }
+
+        view.evaluateJavascript(injectionScript) { _ in
+            logger.debug("Injected Android content blocker CSS")
+        }
     }
 
     /// Notify the host application that an HTTP error has been received from the server while loading a resource.
@@ -1366,6 +1687,33 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
         if let handler = config.schemeHandlers[scheme] {
             return handler.interceptRequest(view: view, request: request)
         }
+        if let blocker = config.contentBlockers?.androidRequestBlocker,
+           let requestURL = URL(string: request.url.toString()) {
+            let headers = WebEngine.androidRequestHeaders(from: request)
+            let decision = blocker.decision(
+                for: AndroidBlockableRequest(
+                    url: requestURL,
+                    mainDocumentURL: WebEngine.androidMainDocumentURL(
+                        for: request,
+                        requestURL: requestURL,
+                        headers: headers
+                    ),
+                    method: request.method,
+                    headers: headers,
+                    isForMainFrame: request.isForMainFrame,
+                    hasGesture: request.hasGesture(),
+                    isRedirect: WebEngine.androidRequestIsRedirect(request),
+                    resourceTypeHint: WebEngine.androidResourceTypeHint(
+                        for: request,
+                        requestURL: requestURL,
+                        headers: headers
+                    )
+                )
+            )
+            if case .block = decision {
+                return WebEngine.blockedAndroidResponse()
+            }
+        }
         return webViewClient.shouldInterceptRequest(view, request)
     }
 
@@ -1401,6 +1749,7 @@ fileprivate class PageLoadDelegate : WebEngineDelegate {
 
     #if SKIP
     override func onPageFinished(view: PlatformWebView, url: String) {
+        super.onPageFinished(view: view, url: url)
         logger.info("webView: \(view) onPageFinished: \(url!)")
         if self.callbackInvoked { return }
         callbackInvoked = true
@@ -1670,6 +2019,8 @@ public extension SkipWebUIDelegate {
     public var messageHandlers: [String: ((WebViewMessage) async -> Void)]
     public var schemeHandlers: [String: URLSchemeHandler]
     public var uiDelegate: (any SkipWebUIDelegate)?
+    public var contentBlockers: WebContentBlockerConfiguration?
+    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
 
     #if SKIP
     /// The Android context to use for creating a web context
@@ -1690,7 +2041,8 @@ public extension SkipWebUIDelegate {
                 userScripts: [WebViewUserScript] = [],
                 messageHandlers: [String: ((WebViewMessage) async -> Void)] = [:],
                 schemeHandlers: [String: URLSchemeHandler] = [:],
-                uiDelegate: (any SkipWebUIDelegate)? = nil) {
+                uiDelegate: (any SkipWebUIDelegate)? = nil,
+                contentBlockers: WebContentBlockerConfiguration? = nil) {
         self.javaScriptEnabled = javaScriptEnabled
         self.javaScriptCanOpenWindowsAutomatically = javaScriptCanOpenWindowsAutomatically
         self.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
@@ -1706,6 +2058,7 @@ public extension SkipWebUIDelegate {
         self.messageHandlers = messageHandlers
         self.schemeHandlers = schemeHandlers
         self.uiDelegate = uiDelegate
+        self.contentBlockers = contentBlockers
     }
 
     public func popupChildMirroredConfiguration() -> WebEngineConfiguration {
@@ -1724,7 +2077,8 @@ public extension SkipWebUIDelegate {
             userScripts: userScripts,
             messageHandlers: messageHandlers,
             schemeHandlers: schemeHandlers,
-            uiDelegate: uiDelegate
+            uiDelegate: uiDelegate,
+            contentBlockers: contentBlockers
         )
         #if SKIP
         copy.context = context
@@ -1752,7 +2106,26 @@ public extension SkipWebUIDelegate {
         }
         #endif
 
+        _ = installContentBlockers(into: configuration.userContentController)
+
         return configuration
+    }
+
+    @MainActor
+    @discardableResult
+    func installContentBlockers(into userContentController: WKUserContentController) -> [WebContentBlockerError] {
+        contentBlockerSetupErrors = []
+        guard let contentBlockers, !contentBlockers.iOSRuleListPaths.isEmpty else {
+            return []
+        }
+
+        let prepared = WebContentBlockerStore.prepareRuleLists(from: contentBlockers.iOSRuleListPaths)
+        contentBlockerSetupErrors = prepared.errors
+        for ruleList in prepared.ruleLists {
+            userContentController.add(ruleList)
+        }
+        WebContentBlockerStore.recordInstallation(count: prepared.ruleLists.count)
+        return prepared.errors
     }
 
     @MainActor private var webKitWebsiteDataStore: WKWebsiteDataStore {
@@ -1801,6 +2174,323 @@ public extension SkipWebUIDelegate {
     }
     #endif
 }
+
+#if !SKIP
+fileprivate struct PreparedContentBlockerRuleLists {
+    let ruleLists: [WKContentRuleList]
+    let errors: [WebContentBlockerError]
+}
+
+struct WebContentBlockerDiagnostics: Equatable {
+    var cacheHitIdentifiers: [String] = []
+    var compiledIdentifiers: [String] = []
+    var prunedIdentifiers: [String] = []
+    var installedRuleListCount: Int = 0
+    var errors: [WebContentBlockerError] = []
+}
+
+@MainActor enum WebContentBlockerDebug {
+    static var diagnostics: WebContentBlockerDiagnostics {
+        WebContentBlockerStore.diagnostics
+    }
+
+    static func resetDiagnostics() {
+        WebContentBlockerStore.diagnostics = WebContentBlockerDiagnostics()
+    }
+
+    static func setBaseDirectoryOverride(_ url: URL?) {
+        WebContentBlockerStore.baseDirectoryOverride = url
+    }
+
+    static func clearPersistentState() throws {
+        try WebContentBlockerStore.clearPersistentState()
+    }
+}
+
+@MainActor
+fileprivate enum WebContentBlockerStore {
+    fileprivate static var baseDirectoryOverride: URL?
+    fileprivate static var diagnostics = WebContentBlockerDiagnostics()
+
+    private struct Metadata: Codable {
+        var version: Int
+        var identifiersBySourcePath: [String: String]
+
+        init(version: Int = 1, identifiersBySourcePath: [String: String] = [:]) {
+            self.version = version
+            self.identifiersBySourcePath = identifiersBySourcePath
+        }
+    }
+
+    private static let metadataFileName = "metadata.json"
+    private static let storeDirectoryName = "RuleListStore"
+    private static let metadataVersion = 1
+
+    static func prepareRuleLists(from sourcePaths: [String]) -> PreparedContentBlockerRuleLists {
+        var ruleLists: [WKContentRuleList] = []
+        var errors: [WebContentBlockerError] = []
+
+        let normalizedSourcePaths = normalizedPaths(from: sourcePaths)
+        guard !normalizedSourcePaths.isEmpty else {
+            diagnostics.errors = []
+            return PreparedContentBlockerRuleLists(ruleLists: [], errors: [])
+        }
+
+        guard let store = makeStore(errors: &errors) else {
+            diagnostics.errors = errors
+            return PreparedContentBlockerRuleLists(ruleLists: [], errors: errors)
+        }
+
+        var metadata = loadMetadata(errors: &errors)
+        let previousIdentifiersBySourcePath = metadata.identifiersBySourcePath
+        var nextIdentifiersBySourcePath: [String: String] = [:]
+        var staleIdentifiers = Set(previousIdentifiersBySourcePath.values)
+
+        for sourcePath in normalizedSourcePaths {
+            let fileURL = URL(fileURLWithPath: sourcePath)
+            let fileData: Data
+            do {
+                fileData = try Data(contentsOf: fileURL)
+            } catch {
+                errors.append(.fileReadFailed(path: sourcePath, description: error.localizedDescription))
+                continue
+            }
+
+            guard let content = String(data: fileData, encoding: .utf8) else {
+                errors.append(.fileEncodingFailed(path: sourcePath))
+                continue
+            }
+
+            let identifier = ruleListIdentifier(for: sourcePath, contentData: fileData)
+            nextIdentifiersBySourcePath[sourcePath] = identifier
+            staleIdentifiers.remove(identifier)
+
+            if let cachedRuleList = lookupRuleList(identifier: identifier, in: store, errors: &errors) {
+                ruleLists.append(cachedRuleList)
+                diagnostics.cacheHitIdentifiers.append(identifier)
+                continue
+            }
+
+            if let compiledRuleList = compileRuleList(identifier: identifier, content: content, sourcePath: sourcePath, in: store, errors: &errors) {
+                ruleLists.append(compiledRuleList)
+                diagnostics.compiledIdentifiers.append(identifier)
+            }
+        }
+
+        let activeIdentifiers = Set(nextIdentifiersBySourcePath.values)
+        for staleIdentifier in staleIdentifiers.subtracting(activeIdentifiers) {
+            removeRuleList(identifier: staleIdentifier, from: store, errors: &errors)
+        }
+
+        metadata.identifiersBySourcePath = nextIdentifiersBySourcePath
+        saveMetadata(metadata, errors: &errors)
+        diagnostics.errors = errors
+
+        return PreparedContentBlockerRuleLists(ruleLists: ruleLists, errors: errors)
+    }
+
+    static func recordInstallation(count: Int) {
+        diagnostics.installedRuleListCount += count
+    }
+
+    static func clearPersistentState() throws {
+        guard let baseDirectory = resolvedBaseDirectoryURL() else {
+            return
+        }
+        if FileManager.default.fileExists(atPath: baseDirectory.path) {
+            try FileManager.default.removeItem(at: baseDirectory)
+        }
+    }
+
+    private static func normalizedPaths(from sourcePaths: [String]) -> [String] {
+        var seen = Set<String>()
+        var normalized: [String] = []
+        for sourcePath in sourcePaths {
+            let path = URL(fileURLWithPath: sourcePath).standardizedFileURL.path
+            if seen.insert(path).inserted {
+                normalized.append(path)
+            }
+        }
+        return normalized
+    }
+
+    private static func ruleListIdentifier(for sourcePath: String, contentData: Data) -> String {
+        "skipweb.content-blocker.\(hexString(Insecure.SHA1.hash(data: Data(sourcePath.utf8)))).\(hexString(SHA256.hash(data: contentData)))"
+    }
+
+    private static func makeStore(errors: inout [WebContentBlockerError]) -> WKContentRuleListStore? {
+        let fileManager = FileManager.default
+        guard let baseDirectory = resolvedBaseDirectoryURL() else {
+            errors.append(.storeUnavailable("Missing application support directory"))
+            return nil
+        }
+
+        let storeDirectory = baseDirectory.appendingPathComponent(storeDirectoryName, isDirectory: true)
+        do {
+            try fileManager.createDirectory(at: storeDirectory, withIntermediateDirectories: true)
+        } catch {
+            errors.append(.storeUnavailable(error.localizedDescription))
+            return nil
+        }
+
+        guard let store = WKContentRuleListStore(url: storeDirectory) else {
+            errors.append(.storeUnavailable("WKContentRuleListStore(url:) returned nil"))
+            return nil
+        }
+        return store
+    }
+
+    private static func resolvedBaseDirectoryURL() -> URL? {
+        if let baseDirectoryOverride {
+            return baseDirectoryOverride
+        }
+        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("SkipWeb", isDirectory: true)
+            .appendingPathComponent("ContentBlockers", isDirectory: true)
+    }
+
+    private static func metadataURL() -> URL? {
+        resolvedBaseDirectoryURL()?.appendingPathComponent(metadataFileName)
+    }
+
+    private static func loadMetadata(errors: inout [WebContentBlockerError]) -> Metadata {
+        guard let metadataURL = metadataURL() else {
+            return Metadata(version: metadataVersion)
+        }
+
+        do {
+            if !FileManager.default.fileExists(atPath: metadataURL.path) {
+                return Metadata(version: metadataVersion)
+            }
+            let data = try Data(contentsOf: metadataURL)
+            return try JSONDecoder().decode(Metadata.self, from: data)
+        } catch {
+            errors.append(.metadataReadFailed(error.localizedDescription))
+            return Metadata(version: metadataVersion)
+        }
+    }
+
+    private static func saveMetadata(_ metadata: Metadata, errors: inout [WebContentBlockerError]) {
+        guard let metadataURL = metadataURL() else {
+            errors.append(.metadataWriteFailed("Missing metadata path"))
+            return
+        }
+
+        do {
+            let baseDirectory = metadataURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(metadata)
+            try data.write(to: metadataURL, options: .atomic)
+        } catch {
+            errors.append(.metadataWriteFailed(error.localizedDescription))
+        }
+    }
+
+    private static func lookupRuleList(identifier: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) -> WKContentRuleList? {
+        switch awaitCallback(description: "lookup \(identifier)") { completion in
+            store.lookUpContentRuleList(forIdentifier: identifier) { ruleList, error in
+                completion(ruleList, error)
+            }
+        } {
+        case .success(let ruleList):
+            return ruleList
+        case .failure(let error as WebContentBlockerError):
+            errors.append(error)
+        case .failure(let error):
+            let nsError = error as NSError
+            if nsError.domain == WKErrorDomain,
+               nsError.code == WKError.Code.contentRuleListStoreLookUpFailed.rawValue {
+                return nil
+            }
+            errors.append(.cacheLookupFailed(identifier: identifier, description: error.localizedDescription))
+        }
+        return nil
+    }
+
+    private static func compileRuleList(identifier: String, content: String, sourcePath: String, in store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) -> WKContentRuleList? {
+        switch awaitCallback(description: "compile \(sourcePath)") { completion in
+            store.compileContentRuleList(forIdentifier: identifier, encodedContentRuleList: content) { ruleList, error in
+                completion(ruleList, error)
+            }
+        } {
+        case .success(let ruleList):
+            return ruleList
+        case .failure(let error as WebContentBlockerError):
+            errors.append(error)
+        case .failure(let error):
+            errors.append(.compilationFailed(path: sourcePath, description: error.localizedDescription))
+        }
+        return nil
+    }
+
+    private static func removeRuleList(identifier: String, from store: WKContentRuleListStore, errors: inout [WebContentBlockerError]) {
+        switch awaitVoidCallback(description: "remove \(identifier)") { completion in
+            store.removeContentRuleList(forIdentifier: identifier) { error in
+                completion(error)
+            }
+        } {
+        case .success:
+            diagnostics.prunedIdentifiers.append(identifier)
+        case .failure(let error as WebContentBlockerError):
+            errors.append(error)
+        case .failure(let error):
+            let nsError = error as NSError
+            // Failing to delete a stale compiled rule list should not prevent the current rule set from loading.
+            if nsError.domain == WKErrorDomain,
+               nsError.code == WKError.Code.contentRuleListStoreRemoveFailed.rawValue {
+                return
+            }
+            errors.append(.staleRuleRemovalFailed(identifier: identifier, description: error.localizedDescription))
+        }
+    }
+
+    private static func awaitCallback<T>(
+        description: String,
+        operation: (@escaping (T?, Error?) -> Void) -> Void
+    ) -> Result<T?, Error> {
+        var result: Result<T?, Error>?
+        operation { value, error in
+            if let error {
+                result = .failure(error)
+            } else {
+                result = .success(value)
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(10.0)
+        while result == nil && deadline.timeIntervalSinceNow > 0 {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
+        return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
+    }
+
+    private static func awaitVoidCallback(
+        description: String,
+        operation: (@escaping (Error?) -> Void) -> Void
+    ) -> Result<Void, Error> {
+        var result: Result<Void, Error>?
+        operation { error in
+            if let error {
+                result = .failure(error)
+            } else {
+                result = .success(())
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(10.0)
+        while result == nil && deadline.timeIntervalSinceNow > 0 {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+        }
+
+        return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
+    }
+
+    private static func hexString<D: Digest>(_ digest: D) -> String {
+        digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+#endif
 
 public class WebHistoryItem {
     #if !SKIP

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -11,6 +11,7 @@ import CryptoKit
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import androidx.webkit.WebResourceRequestCompat
+import androidx.webkit.ScriptHandler
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import kotlin.coroutines.suspendCoroutine
@@ -229,16 +230,70 @@ public struct AndroidPageContext: Equatable, Sendable {
     }
 }
 
-public struct AndroidCosmeticPayload: Equatable, Sendable {
-    public var css: [String]
+public enum AndroidCosmeticFrameScope: String, CaseIterable, Hashable, Sendable {
+    case mainFrameOnly
+    case subframesOnly
+    case allFrames
+}
 
-    public init(css: [String] = []) {
+public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Sendable {
+    case documentStart
+    case pageLifecycle
+}
+
+public struct AndroidCosmeticRule: Equatable, Sendable {
+    public var css: [String]
+    public var urlFilterPattern: String?
+    public var allowedOriginRules: [String]
+    public var frameScope: AndroidCosmeticFrameScope
+    public var preferredTiming: AndroidCosmeticInjectionTiming
+
+    public init(
+        css: [String] = [],
+        urlFilterPattern: String? = nil,
+        allowedOriginRules: [String] = ["*"],
+        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
+        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
+    ) {
         self.css = css
+        self.urlFilterPattern = urlFilterPattern
+        self.allowedOriginRules = allowedOriginRules
+        self.frameScope = frameScope
+        self.preferredTiming = preferredTiming
+    }
+
+    /// Convenience initializer for selector-based hiding, matching iOS `css-display-none`.
+    public init(
+        hiddenSelectors: [String],
+        urlFilterPattern: String? = nil,
+        allowedOriginRules: [String] = ["*"],
+        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
+        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
+    ) {
+        self.init(
+            css: Self.hideCSS(for: hiddenSelectors),
+            urlFilterPattern: urlFilterPattern,
+            allowedOriginRules: allowedOriginRules,
+            frameScope: frameScope,
+            preferredTiming: preferredTiming
+        )
+    }
+
+    fileprivate static func hideCSS(for selectors: [String]) -> [String] {
+        selectors
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { "\($0) { display: none !important; }" }
     }
 }
 
 public protocol AndroidCosmeticBlocker {
-    func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload?
+    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+}
+
+struct AndroidCosmeticInjectionPlan {
+    var documentStartRules: [AndroidCosmeticRule] = []
+    var lifecycleCSS: [String] = []
 }
 
 public enum WebContentBlockerError: Error, Equatable, LocalizedError {
@@ -698,6 +753,9 @@ extension WebCookie {
         if profileSetupError != nil {
             return
         }
+        #if SKIP
+        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: url)
+        #endif
         webView.reload()
     }
 
@@ -723,6 +781,9 @@ extension WebCookie {
         if profileSetupError != nil {
             return
         }
+        #if SKIP
+        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: -1))
+        #endif
         webView.goBack()
     }
 
@@ -730,6 +791,9 @@ extension WebCookie {
         if profileSetupError != nil {
             return
         }
+        #if SKIP
+        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: 1))
+        #endif
         webView.goForward()
     }
 
@@ -745,6 +809,37 @@ extension WebCookie {
         webView.url
         #endif
     }
+
+    #if SKIP
+    private func prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: URL?) {
+        guard let targetURL else {
+            return
+        }
+        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: targetURL, in: webView)
+    }
+
+    private func pendingHistoryNavigationURL(offset: Int) -> URL? {
+        let historyList = webView.copyBackForwardList()
+        guard let targetIndex = Self.androidHistoryNavigationIndex(
+            currentIndex: historyList.currentIndex,
+            size: historyList.size,
+            offset: offset
+        ) else {
+            return nil
+        }
+
+        let targetItem = historyList.getItemAtIndex(targetIndex)
+        return URL(string: targetItem.getUrl()) ?? URL(string: targetItem.getOriginalUrl())
+    }
+
+    static func androidHistoryNavigationIndex(currentIndex: Int, size: Int, offset: Int) -> Int? {
+        let targetIndex = currentIndex + offset
+        guard targetIndex >= 0, targetIndex < size else {
+            return nil
+        }
+        return targetIndex
+    }
+    #endif
 
     /// Evaluates the given JavaScript string and returns the resulting JSON string, which may be a top-level fragment
     public func evaluate(js: String) async throws -> String? {
@@ -783,6 +878,10 @@ extension WebCookie {
 
     public static func isAndroidMultiProfileSupported() -> Bool {
         WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE)
+    }
+
+    public static func isAndroidDocumentStartScriptSupported() -> Bool {
+        WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
     }
 
     private static func configureAndroidProfile(_ profile: WebProfile, for webView: PlatformWebView) -> Result<AndroidProfileResources, WebProfileError> {
@@ -1122,6 +1221,10 @@ extension WebCookie {
         }
         logger.info("loadHTML webView: \(self.description)")
         let encoding: String = "UTF-8"
+        #if SKIP
+        let cosmeticPageURL = baseURL ?? URL(string: "about:blank")!
+        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: cosmeticPageURL, in: webView)
+        #endif
 
         #if SKIP
         // see https://developer.android.com/reference/android/webkit/WebView#loadDataWithBaseURL(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String)
@@ -1143,6 +1246,9 @@ extension WebCookie {
         try throwProfileSetupErrorIfNeeded()
         let urlString = url.absoluteString
         logger.info("load URL=\(urlString) webView: \(self.description)")
+        #if SKIP
+        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: url, in: webView)
+        #endif
         try await awaitPageLoaded {
             #if SKIP
             webView.loadUrl(urlString ?? "about:blank")
@@ -1368,11 +1474,237 @@ extension WebCookie {
         }
     }
 
-    fileprivate static func androidContentBlockerStyleInjectionScript(cssPayload: AndroidCosmeticPayload) -> String? {
-        let css = cssPayload.css
+    fileprivate static func normalizedAndroidCosmeticCSS(_ cssRules: [String]) -> [String] {
+        cssRules
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-            .joined(separator: "\n")
+    }
+
+    fileprivate static func normalizedAndroidAllowedOriginRules(_ allowedOriginRules: [String]) -> [String] {
+        let normalized = allowedOriginRules
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return normalized.isEmpty ? ["*"] : normalized
+    }
+
+    fileprivate static func androidDefaultPort(for scheme: String) -> Int? {
+        switch scheme.lowercased() {
+        case "http":
+            return 80
+        case "https":
+            return 443
+        default:
+            return nil
+        }
+    }
+
+    fileprivate static func androidParsedOriginRule(_ rule: String) -> (scheme: String, host: String?, port: Int?)? {
+        let normalizedRule = rule.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let separatorRange = normalizedRule.range(of: "://") else {
+            return nil
+        }
+
+        let scheme = String(normalizedRule[..<separatorRange.lowerBound]).lowercased()
+        guard !scheme.isEmpty else {
+            return nil
+        }
+        var authority = String(normalizedRule[separatorRange.upperBound...])
+        if let pathStart = authority.firstIndex(where: { $0 == "/" || $0 == "?" || $0 == "#" }) {
+            authority = String(authority[..<pathStart])
+        }
+
+        guard !authority.isEmpty else {
+            return (scheme, nil, nil)
+        }
+
+        if authority.hasPrefix("[") {
+            guard let bracketEnd = authority.firstIndex(of: "]") else {
+                return nil
+            }
+            let host = String(authority[authority.index(after: authority.startIndex)..<bracketEnd]).lowercased()
+            let remainder = authority[authority.index(after: bracketEnd)...]
+            guard !remainder.isEmpty else {
+                return (scheme, host, nil)
+            }
+            guard remainder.first == ":" else {
+                return nil
+            }
+            return (scheme, host, Int(String(remainder.dropFirst())))
+        }
+
+        if let colonIndex = authority.lastIndex(of: ":"),
+           androidDigitsOnly(String(authority[authority.index(after: colonIndex)...])) {
+            let host = String(authority[..<colonIndex]).lowercased()
+            return (scheme, host, Int(String(authority[authority.index(after: colonIndex)...])))
+        }
+
+        return (scheme, authority.lowercased(), nil)
+    }
+
+    fileprivate static func androidDigitsOnly(_ value: String) -> Bool {
+        guard !value.isEmpty else {
+            return false
+        }
+        for character in value {
+            guard character >= "0" && character <= "9" else {
+                return false
+            }
+        }
+        return true
+    }
+
+    fileprivate static func androidOriginRule(_ rule: String, matches pageURL: URL) -> Bool {
+        let normalizedRule = rule.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedRule.isEmpty else {
+            return false
+        }
+        if normalizedRule == "*" {
+            return true
+        }
+
+        guard
+            let parsedRule = androidParsedOriginRule(normalizedRule),
+            let pageScheme = pageURL.scheme?.lowercased(),
+            parsedRule.scheme == pageScheme
+        else {
+            return false
+        }
+
+        let defaultPort = androidDefaultPort(for: parsedRule.scheme)
+        if parsedRule.scheme != "http" && parsedRule.scheme != "https" {
+            return parsedRule.host == nil && parsedRule.port == nil
+        }
+
+        guard
+            let ruleHost = parsedRule.host,
+            let pageHost = pageURL.host?.lowercased()
+        else {
+            return false
+        }
+
+        let pagePort = pageURL.port ?? defaultPort
+        let rulePort = parsedRule.port ?? defaultPort
+        guard pagePort == rulePort else {
+            return false
+        }
+
+        if ruleHost.hasPrefix("*.") {
+            let suffix = String(ruleHost.dropFirst(2))
+            return pageHost.hasSuffix(".\(suffix)")
+        }
+
+        return pageHost == ruleHost
+    }
+
+    fileprivate static func androidAllowedOriginRulesMatchPage(_ allowedOriginRules: [String], pageURL: URL) -> Bool {
+        let normalizedRules = normalizedAndroidAllowedOriginRules(allowedOriginRules)
+        return normalizedRules.contains { androidOriginRule($0, matches: pageURL) }
+    }
+
+    fileprivate static func androidURLFilterPatternMatchesPage(_ urlFilterPattern: String?, pageURL: URL) -> Bool {
+        guard let urlFilterPattern, !urlFilterPattern.isEmpty else {
+            return true
+        }
+
+        let pageURLString = pageURL.absoluteString
+        #if SKIP
+        // SKIP INSERT: try { return kotlin.text.Regex(urlFilterPattern).containsMatchIn(pageURLString) } catch (t: Throwable) { return false }
+        return false
+        #else
+        let range = NSRange(location: 0, length: pageURLString.utf16.count)
+        guard let expression = try? NSRegularExpression(pattern: urlFilterPattern) else {
+            return false
+        }
+        return expression.firstMatch(in: pageURLString, range: range) != nil
+        #endif
+    }
+
+    static func androidCosmeticInjectionPlan(
+        rules: [AndroidCosmeticRule],
+        pageURL: URL,
+        isDocumentStartSupported: Bool,
+        log: ((String) -> Void)? = nil
+    ) -> AndroidCosmeticInjectionPlan {
+        var plan = AndroidCosmeticInjectionPlan()
+
+        for rule in rules {
+            let normalizedCSS = normalizedAndroidCosmeticCSS(rule.css)
+            guard !normalizedCSS.isEmpty else {
+                continue
+            }
+
+            switch rule.preferredTiming {
+            case .documentStart:
+                if isDocumentStartSupported {
+                    var normalizedRule = rule
+                    normalizedRule.css = normalizedCSS
+                    normalizedRule.allowedOriginRules = normalizedAndroidAllowedOriginRules(rule.allowedOriginRules)
+                    plan.documentStartRules.append(normalizedRule)
+                } else if rule.frameScope == .mainFrameOnly,
+                          androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
+                          androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
+                    plan.lifecycleCSS.append(contentsOf: normalizedCSS)
+                } else if rule.frameScope == .mainFrameOnly {
+                    if !androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL) {
+                        log?("Skipping Android cosmetic rule because page origin does not match allowedOriginRules")
+                    } else {
+                        log?("Skipping Android cosmetic rule because page URL does not match urlFilterPattern")
+                    }
+                } else {
+                    log?("Skipping Android cosmetic rule with frameScope=\(rule.frameScope.rawValue) because document-start frame injection is unavailable")
+                }
+            case .pageLifecycle:
+                if rule.frameScope == .mainFrameOnly,
+                   androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
+                   androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
+                    plan.lifecycleCSS.append(contentsOf: normalizedCSS)
+                } else if rule.frameScope == .mainFrameOnly {
+                    if !androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL) {
+                        log?("Skipping Android cosmetic rule because page origin does not match allowedOriginRules")
+                    } else {
+                        log?("Skipping Android cosmetic rule because page URL does not match urlFilterPattern")
+                    }
+                } else {
+                    log?("Skipping Android cosmetic rule with frameScope=\(rule.frameScope.rawValue) because page-lifecycle injection only supports the main frame")
+                }
+            }
+        }
+
+        return plan
+    }
+
+    static func androidRedirectFallbackCosmeticPlan(
+        rules: [AndroidCosmeticRule],
+        pageURL: URL,
+        log: ((String) -> Void)? = nil
+    ) -> AndroidCosmeticInjectionPlan {
+        androidCosmeticInjectionPlan(
+            rules: rules,
+            pageURL: pageURL,
+            isDocumentStartSupported: false,
+            log: log
+        )
+    }
+
+    static func androidContentBlockerStyleRemovalScript(styleID: String) -> String {
+        let styleIDLiteral = styleID.replacingOccurrences(of: "\"", with: "\\\"")
+        return """
+        (function() {
+            var style = document.getElementById("\(styleIDLiteral)");
+            if (style) {
+                style.remove();
+            }
+        })();
+        """
+    }
+
+    static func androidContentBlockerStyleInjectionScript(
+        cssRules: [String],
+        styleID: String,
+        frameScope: AndroidCosmeticFrameScope,
+        urlFilterPattern: String? = nil
+    ) -> String? {
+        let css = normalizedAndroidCosmeticCSS(cssRules).joined(separator: "\n")
         guard !css.isEmpty else {
             return nil
         }
@@ -1383,9 +1715,40 @@ extension WebCookie {
             return nil
         }
         let cssLiteral = String(encoded.dropFirst().dropLast())
+        let styleIDLiteral = styleID.replacingOccurrences(of: "\"", with: "\\\"")
+        let urlFilterGuard: String
+        if let urlFilterPattern, !urlFilterPattern.isEmpty {
+            guard
+                let patternData = try? JSONSerialization.data(withJSONObject: [urlFilterPattern], options: []),
+                let patternEncoded = String(data: patternData, encoding: .utf8)
+            else {
+                return nil
+            }
+            let patternLiteral = String(patternEncoded.dropFirst().dropLast())
+            urlFilterGuard = """
+            try {
+                if (!(new RegExp(\(patternLiteral))).test(window.location.href)) { return; }
+            } catch (error) {
+                return;
+            }
+            """
+        } else {
+            urlFilterGuard = ""
+        }
+        let frameGuard: String
+        switch frameScope {
+        case .mainFrameOnly:
+            frameGuard = "if (window.top !== window.self) { return; }"
+        case .subframesOnly:
+            frameGuard = "if (window.top === window.self) { return; }"
+        case .allFrames:
+            frameGuard = ""
+        }
         return """
         (function() {
-            var styleId = "__skipweb_content_blockers";
+            \(frameGuard)
+            \(urlFilterGuard)
+            var styleId = "\(styleIDLiteral)";
             var css = \(cssLiteral);
             var root = document.head || document.documentElement;
             if (!root) { return; }
@@ -1529,6 +1892,9 @@ extension WebEngine {
 public class WebEngineDelegate : android.webkit.WebViewClient {
     let config: WebEngineConfiguration
     let webViewClient: android.webkit.WebViewClient
+    private var androidCosmeticScriptHandlers: [ScriptHandler] = []
+    private var androidLifecycleCosmeticCSS: [String] = []
+    private var androidPreparedCosmeticPageURL: String?
     
     override init(config: WebEngineConfiguration, webViewClient: android.webkit.WebViewClient = android.webkit.WebViewClient()) {
         super.init()
@@ -1557,14 +1923,16 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     /// Notify the host application that WebView content left over from previous page navigations will no longer be drawn.
     override func onPageCommitVisible(view: PlatformWebView, url: String) {
         logger.log("onPageCommitVisible: \(url)")
-        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
+        recoverAndroidCosmeticsIfNeeded(for: url)
+        injectAndroidContentBlockerCSSIfNeeded(into: view)
         webViewClient.onPageCommitVisible(view, url)
     }
 
     /// Notify the host application that a page has finished loading.
     override func onPageFinished(view: PlatformWebView, url: String) {
         logger.log("onPageFinished: \(url)")
-        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
+        recoverAndroidCosmeticsIfNeeded(for: url)
+        injectAndroidContentBlockerCSSIfNeeded(into: view)
         for userScript in config.userScripts {
             if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
                 let source = userScript.webKitUserScript.source
@@ -1579,6 +1947,7 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     /// Notify the host application that a page has started loading.
     override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
         logger.log("onPageStarted: \(url)")
+        recoverAndroidCosmeticsIfNeeded(for: url)
         if (!config.messageHandlers.isEmpty) {
             // add support for webkit.messageHandlers.messageHandlerName.postMessage(body)
             // JS Proxies are pretty weird. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
@@ -1602,7 +1971,7 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
                 }
             }
         }
-        injectAndroidContentBlockerCSSIfNeeded(into: view, url: url)
+        injectAndroidContentBlockerCSSIfNeeded(into: view)
         webViewClient.onPageStarted(view, url, favicon)
     }
 
@@ -1624,13 +1993,116 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
         webViewClient.onReceivedHttpAuthRequest(view, handler, host, realm)
     }
 
-    private func injectAndroidContentBlockerCSSIfNeeded(into view: PlatformWebView, url: String) {
-        guard let blocker = config.contentBlockers?.androidCosmeticBlocker,
-              let pageURL = URL(string: url),
-              let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
-                  cssPayload: blocker.cosmetics(for: AndroidPageContext(url: pageURL)) ?? AndroidCosmeticPayload()
-              )
-        else {
+    private func removeAllAndroidCosmeticScriptHandlers() {
+        for handler in androidCosmeticScriptHandlers {
+            handler.remove()
+        }
+        androidCosmeticScriptHandlers.removeAll()
+    }
+
+    private func androidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
+        guard let blocker = config.contentBlockers?.androidCosmeticBlocker else {
+            return AndroidCosmeticInjectionPlan()
+        }
+        return WebEngine.androidCosmeticInjectionPlan(
+            rules: blocker.cosmetics(for: AndroidPageContext(url: pageURL)),
+            pageURL: pageURL,
+            isDocumentStartSupported: WebEngine.isAndroidDocumentStartScriptSupported()
+        ) { message in
+            logger.warning("\(message) for \(pageURL.absoluteString)")
+        }
+    }
+
+    private func fallbackAndroidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
+        guard let blocker = config.contentBlockers?.androidCosmeticBlocker else {
+            return AndroidCosmeticInjectionPlan()
+        }
+        return WebEngine.androidRedirectFallbackCosmeticPlan(
+            rules: blocker.cosmetics(for: AndroidPageContext(url: pageURL)),
+            pageURL: pageURL
+        ) { message in
+            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        }
+    }
+
+    private func registerAndroidDocumentStartCosmeticRule(
+        _ rule: AndroidCosmeticRule,
+        index: Int,
+        for pageURL: URL,
+        in view: PlatformWebView
+    ) -> ScriptHandler? {
+        guard let script = WebEngine.androidContentBlockerStyleInjectionScript(
+            cssRules: rule.css,
+            styleID: "__skipweb_content_blockers_\(index)",
+            frameScope: rule.frameScope,
+            urlFilterPattern: rule.urlFilterPattern
+        ) else {
+            return nil
+        }
+        let allowedOriginRules: kotlin.collections.MutableSet<String> = kotlin.collections.HashSet()
+        for allowedOriginRule in rule.allowedOriginRules {
+            allowedOriginRules.add(allowedOriginRule)
+        }
+
+        // SKIP INSERT: try {
+        // SKIP INSERT:     return androidx.webkit.WebViewCompat.addDocumentStartJavaScript(view, script_0, allowedOriginRules)
+        // SKIP INSERT: } catch (t: Throwable) {
+        // SKIP INSERT:     logger.warning("Skipping Android cosmetic rule registration for ${pageURL.absoluteString}: ${t.message ?: t}")
+        // SKIP INSERT:     return null
+        // SKIP INSERT: }
+        return WebViewCompat.addDocumentStartJavaScript(view, script, allowedOriginRules)
+    }
+
+    fileprivate func prepareAndroidCosmeticRules(for pageURL: URL, in view: PlatformWebView) {
+        removeAllAndroidCosmeticScriptHandlers()
+        let plan = androidCosmeticPlan(for: pageURL)
+        androidLifecycleCosmeticCSS = plan.lifecycleCSS
+
+        if WebEngine.isAndroidDocumentStartScriptSupported() {
+            for (index, rule) in plan.documentStartRules.enumerated() {
+                if let handler = registerAndroidDocumentStartCosmeticRule(rule, index: index, for: pageURL, in: view) {
+                    androidCosmeticScriptHandlers.append(handler)
+                }
+            }
+        }
+
+        androidPreparedCosmeticPageURL = pageURL.absoluteString
+    }
+
+    private func recoverAndroidCosmeticsIfNeeded(for url: String) {
+        guard androidPreparedCosmeticPageURL != url else {
+            return
+        }
+        guard let pageURL = URL(string: url) else {
+            removeAllAndroidCosmeticScriptHandlers()
+            androidLifecycleCosmeticCSS = []
+            androidPreparedCosmeticPageURL = nil
+            return
+        }
+
+        if androidPreparedCosmeticPageURL != nil {
+            logger.info("Falling back to late Android cosmetic injection for \(pageURL.absoluteString)")
+        }
+        removeAllAndroidCosmeticScriptHandlers()
+        let fallbackPlan = fallbackAndroidCosmeticPlan(for: pageURL)
+        androidLifecycleCosmeticCSS = fallbackPlan.lifecycleCSS
+        androidPreparedCosmeticPageURL = pageURL.absoluteString
+    }
+
+    private func clearAndroidContentBlockerCSS(in view: PlatformWebView) {
+        let removalScript = WebEngine.androidContentBlockerStyleRemovalScript(styleID: "__skipweb_content_blockers")
+        view.evaluateJavascript(removalScript) { _ in
+            logger.debug("Cleared Android content blocker CSS")
+        }
+    }
+
+    private func injectAndroidContentBlockerCSSIfNeeded(into view: PlatformWebView) {
+        guard let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
+            cssRules: androidLifecycleCosmeticCSS,
+            styleID: "__skipweb_content_blockers",
+            frameScope: .mainFrameOnly
+        ) else {
+            clearAndroidContentBlockerCSS(in: view)
             return
         }
 
@@ -1726,6 +2198,9 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     /// Give the host application a chance to take control when a URL is about to be loaded in the current WebView.
     override func shouldOverrideUrlLoading(view: PlatformWebView, request: android.webkit.WebResourceRequest) -> Bool {
         logger.log("shouldOverrideUrlLoading: \(request.url)")
+        if request.isForMainFrame, let url = URL(string: request.url.toString()) {
+            prepareAndroidCosmeticRules(for: url, in: view)
+        }
         return webViewClient.shouldOverrideUrlLoading(view, request)
     }
 }

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -152,21 +152,46 @@ public enum WebProfileError: Error, Equatable {
 
 public struct WebContentBlockerConfiguration {
     public var iOSRuleListPaths: [String]
+    public var androidMode: AndroidContentBlockingMode
+    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
     public var androidRequestBlocker: (any AndroidRequestBlocker)?
+    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
     public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
 
     public init(
         iOSRuleListPaths: [String] = [],
+        androidMode: AndroidContentBlockingMode = .disabled,
         androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
         androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
     ) {
         self.iOSRuleListPaths = iOSRuleListPaths
+        self.androidMode = androidMode
         self.androidRequestBlocker = androidRequestBlocker
         self.androidCosmeticBlocker = androidCosmeticBlocker
     }
 }
 
-public enum AndroidRequestBlockDecision: Sendable {
+public protocol AndroidContentBlockingProvider {
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+}
+
+public extension AndroidContentBlockingProvider {
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+        .allow
+    }
+
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        []
+    }
+}
+
+public enum AndroidContentBlockingMode {
+    case disabled
+    case custom(any AndroidContentBlockingProvider)
+}
+
+public enum AndroidRequestBlockDecision: Equatable, Sendable {
     case allow
     case block
 }
@@ -291,9 +316,76 @@ public protocol AndroidCosmeticBlocker {
     func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
 }
 
+public protocol SkipWebNavigationDelegate {
+    func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool
+    func webEngineDidCommitNavigation(_ engine: WebEngine)
+    func webEngineDidFinishNavigation(_ engine: WebEngine)
+    func webEngine(_ engine: WebEngine, didFailNavigation error: Error)
+}
+
+public extension SkipWebNavigationDelegate {
+    func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool {
+        false
+    }
+
+    func webEngineDidCommitNavigation(_ engine: WebEngine) {
+    }
+
+    func webEngineDidFinishNavigation(_ engine: WebEngine) {
+    }
+
+    func webEngine(_ engine: WebEngine, didFailNavigation error: Error) {
+    }
+}
+
 struct AndroidCosmeticInjectionPlan {
     var documentStartRules: [AndroidCosmeticRule] = []
     var lifecycleCSS: [String] = []
+}
+
+fileprivate struct LegacyAndroidContentBlockingProvider: AndroidContentBlockingProvider {
+    let requestBlocker: (any AndroidRequestBlocker)?
+    let cosmeticBlocker: (any AndroidCosmeticBlocker)?
+
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+        requestBlocker?.decision(for: request) ?? .allow
+    }
+
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        cosmeticBlocker?.cosmetics(for: page) ?? []
+    }
+}
+
+extension WebContentBlockerConfiguration {
+    var hasLegacyAndroidHooks: Bool {
+        androidRequestBlocker != nil || androidCosmeticBlocker != nil
+    }
+
+    var effectiveAndroidMode: AndroidContentBlockingMode {
+        switch androidMode {
+        case .disabled:
+            if hasLegacyAndroidHooks {
+                return .custom(
+                    LegacyAndroidContentBlockingProvider(
+                        requestBlocker: androidRequestBlocker,
+                        cosmeticBlocker: androidCosmeticBlocker
+                    )
+                )
+            }
+            return .disabled
+        case .custom:
+            return androidMode
+        }
+    }
+
+    var effectiveAndroidProvider: (any AndroidContentBlockingProvider)? {
+        switch effectiveAndroidMode {
+        case .disabled:
+            return nil
+        case .custom(let provider):
+            return provider
+        }
+    }
 }
 
 public enum WebContentBlockerError: Error, Equatable, LocalizedError {
@@ -715,6 +807,11 @@ extension WebCookie {
     private var profileSetupError: WebProfileError?
     private var androidProfileCookieManager: android.webkit.CookieManager?
     private var androidProfileWebStorage: android.webkit.WebStorage?
+    fileprivate lazy var androidContentBlockerController = AndroidContentBlockerController(config: configuration)
+    private lazy var androidInternalWebViewClient = AndroidEngineWebViewClient(engine: self)
+    private var androidEmbeddedNavigationClient: android.webkit.WebViewClient?
+    private var androidLegacyNavigationDelegate: WebEngineDelegate?
+    private var androidPendingPageLoadCallbacks: [UUID: (Result<Void, Error>) -> Void] = [:]
     #endif
 
     /// Create a WebEngine with the specified configuration.
@@ -736,6 +833,7 @@ extension WebCookie {
             self.profileSetupError = .invalidProfileName
         }
         #else
+        let suppliedAndroidWebViewClient = webView?.webViewClient
         // fall back to using the global android context if the activity context is not set in the configuration
         self.webView = webView ?? PlatformWebView(configuration.context ?? ProcessInfo.processInfo.androidContext)
         switch Self.configureAndroidProfile(configuration.profile, for: self.webView) {
@@ -746,6 +844,11 @@ extension WebCookie {
         case .failure(let error):
             self.profileSetupError = error
         }
+        if let suppliedAndroidWebViewClient,
+           !(suppliedAndroidWebViewClient is AndroidEngineWebViewClient) {
+            setAndroidEmbeddedNavigationClient(suppliedAndroidWebViewClient)
+        }
+        self.webView.webViewClient = androidInternalWebViewClient
         #endif
     }
 
@@ -754,7 +857,7 @@ extension WebCookie {
             return
         }
         #if SKIP
-        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: url)
+        prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: url)
         #endif
         webView.reload()
     }
@@ -782,7 +885,7 @@ extension WebCookie {
             return
         }
         #if SKIP
-        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: -1))
+        prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: -1))
         #endif
         webView.goBack()
     }
@@ -792,7 +895,7 @@ extension WebCookie {
             return
         }
         #if SKIP
-        prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: 1))
+        prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: pendingHistoryNavigationURL(offset: 1))
         #endif
         webView.goForward()
     }
@@ -811,11 +914,11 @@ extension WebCookie {
     }
 
     #if SKIP
-    private func prepareAndroidCosmeticRulesForPendingMainFrameNavigation(targetURL: URL?) {
+    private func prepareAndroidContentBlockersForPendingMainFrameNavigation(targetURL: URL?) {
         guard let targetURL else {
             return
         }
-        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: targetURL, in: webView)
+        androidContentBlockerController.prepare(for: targetURL, in: webView)
     }
 
     private func pendingHistoryNavigationURL(offset: Int) -> URL? {
@@ -838,6 +941,28 @@ extension WebCookie {
             return nil
         }
         return targetIndex
+    }
+
+    func setAndroidEmbeddedNavigationClient(_ client: android.webkit.WebViewClient?) {
+        androidEmbeddedNavigationClient = client
+        androidInternalWebViewClient.embeddedNavigationClient = client
+    }
+
+    func setAndroidLegacyNavigationDelegate(_ delegate: WebEngineDelegate?) {
+        androidLegacyNavigationDelegate = delegate
+        androidInternalWebViewClient.legacyNavigationDelegate = delegate
+    }
+
+    func completeAndroidPageLoad(_ result: Result<Void, Error>) {
+        let callbacks = androidPendingPageLoadCallbacks.values
+        androidPendingPageLoadCallbacks.removeAll()
+        for callback in callbacks {
+            callback(result)
+        }
+    }
+
+    var androidNavigationDelegate: (any SkipWebNavigationDelegate)? {
+        configuration.navigationDelegate
     }
     #endif
 
@@ -1223,7 +1348,7 @@ extension WebCookie {
         let encoding: String = "UTF-8"
         #if SKIP
         let cosmeticPageURL = baseURL ?? URL(string: "about:blank")!
-        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: cosmeticPageURL, in: webView)
+        androidContentBlockerController.prepare(for: cosmeticPageURL, in: webView)
         #endif
 
         #if SKIP
@@ -1247,7 +1372,7 @@ extension WebCookie {
         let urlString = url.absoluteString
         logger.info("load URL=\(urlString) webView: \(self.description)")
         #if SKIP
-        (engineDelegate as? WebEngineDelegate)?.prepareAndroidCosmeticRules(for: url, in: webView)
+        androidContentBlockerController.prepare(for: url, in: webView)
         #endif
         try await awaitPageLoaded {
             #if SKIP
@@ -1768,6 +1893,20 @@ extension WebCookie {
     // SKIP @nobridge
     public func awaitPageLoaded(_ block: () -> ()) async throws {
         try throwProfileSetupErrorIfNeeded()
+        #if SKIP
+        let token = UUID()
+        defer {
+            androidPendingPageLoadCallbacks.removeValue(forKey: token)
+        }
+
+        let _: Void? = try await withCheckedThrowingContinuation { continuation in
+            androidPendingPageLoadCallbacks[token] = { result in
+                continuation.resume(with: result)
+            }
+            logger.log("WebEngine: awaitPageLoaded block()")
+            block()
+        }
+        #else
         let pdelegate = self.engineDelegate
         defer { self.engineDelegate = pdelegate }
 
@@ -1783,6 +1922,7 @@ extension WebCookie {
             logger.log("WebEngine: awaitPageLoaded block()")
             block()
         }
+        #endif
     }
     
     #if !SKIP
@@ -1866,10 +2006,11 @@ extension WebEngine: ScriptMessageHandler {
 extension WebEngine {
     /// The engine delegate that handles client navigation events like the page being loaded or an error occuring
     // SKIP @nobridge
+    @available(*, deprecated, message: "Use WebEngineConfiguration.navigationDelegate for app navigation hooks. Android installs an internal WebViewClient for blocker enforcement.")
     public var engineDelegate: WebEngineDelegate? {
         get {
             #if SKIP
-            webView.webViewClient as? WebEngineDelegate
+            androidLegacyNavigationDelegate
             #else
             webView.navigationDelegate as? WebEngineDelegate
             #endif
@@ -1877,7 +2018,7 @@ extension WebEngine {
 
         set {
             #if SKIP
-            webView.webViewClient = newValue ?? webView.webViewClient
+            setAndroidLegacyNavigationDelegate(newValue)
             #else
             webView.navigationDelegate = newValue
             #endif
@@ -1888,109 +2029,100 @@ extension WebEngine {
 
 
 #if SKIP
-// SKIP @nobridge
-public class WebEngineDelegate : android.webkit.WebViewClient {
+final class AndroidContentBlockerController {
     let config: WebEngineConfiguration
-    let webViewClient: android.webkit.WebViewClient
     private var androidCosmeticScriptHandlers: [ScriptHandler] = []
     private var androidLifecycleCosmeticCSS: [String] = []
     private var androidPreparedCosmeticPageURL: String?
-    
-    override init(config: WebEngineConfiguration, webViewClient: android.webkit.WebViewClient = android.webkit.WebViewClient()) {
-        super.init()
+
+    init(config: WebEngineConfiguration) {
         self.config = config
-        self.webViewClient = webViewClient
     }
 
-    /// Notify the host application to update its visited links database.
-    override func doUpdateVisitedHistory(view: PlatformWebView, url: String, isReload: Bool) {
-        logger.log("application")
-        webViewClient.doUpdateVisitedHistory(view, url, isReload)
+    private var provider: (any AndroidContentBlockingProvider)? {
+        config.contentBlockers?.effectiveAndroidProvider
     }
 
-    /// As the host application if the browser should resend data as the requested page was a result of a POST.
-    override func onFormResubmission(view: PlatformWebView, dontResend: android.os.Message, resend: android.os.Message) {
-        logger.log("onFormResubmission")
-        webViewClient.onFormResubmission(view, dontResend, resend)
-    }
+    func prepare(for pageURL: URL, in view: PlatformWebView) {
+        removeAllAndroidCosmeticScriptHandlers()
+        let plan = androidCosmeticPlan(for: pageURL)
+        androidLifecycleCosmeticCSS = plan.lifecycleCSS
 
-    /// Notify the host application that the WebView will load the resource specified by the given url.
-    override func onLoadResource(view: PlatformWebView, url: String) {
-        logger.log("onLoadResource: \(url)")
-        webViewClient.onLoadResource(view, url)
-    }
-
-    /// Notify the host application that WebView content left over from previous page navigations will no longer be drawn.
-    override func onPageCommitVisible(view: PlatformWebView, url: String) {
-        logger.log("onPageCommitVisible: \(url)")
-        recoverAndroidCosmeticsIfNeeded(for: url)
-        injectAndroidContentBlockerCSSIfNeeded(into: view)
-        webViewClient.onPageCommitVisible(view, url)
-    }
-
-    /// Notify the host application that a page has finished loading.
-    override func onPageFinished(view: PlatformWebView, url: String) {
-        logger.log("onPageFinished: \(url)")
-        recoverAndroidCosmeticsIfNeeded(for: url)
-        injectAndroidContentBlockerCSSIfNeeded(into: view)
-        for userScript in config.userScripts {
-            if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
-                let source = userScript.webKitUserScript.source
-                view.evaluateJavascript(source) { _ in
-                    logger.debug("Executed user script \(source)")
+        if WebEngine.isAndroidDocumentStartScriptSupported() {
+            for (index, rule) in plan.documentStartRules.enumerated() {
+                if let handler = registerAndroidDocumentStartCosmeticRule(rule, index: index, for: pageURL, in: view) {
+                    androidCosmeticScriptHandlers.append(handler)
                 }
             }
         }
-        webViewClient.onPageFinished(view, url)
+
+        androidPreparedCosmeticPageURL = pageURL.absoluteString
     }
 
-    /// Notify the host application that a page has started loading.
-    override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
-        logger.log("onPageStarted: \(url)")
-        recoverAndroidCosmeticsIfNeeded(for: url)
-        if (!config.messageHandlers.isEmpty) {
-            // add support for webkit.messageHandlers.messageHandlerName.postMessage(body)
-            // JS Proxies are pretty weird. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
-            // We're using an empty target; when JS accesses any property,
-            // we'll return a JS object with a `postMessage` member function, which will call
-            // skipWebAndroidMessageHandler.postMessage, passing the messageHandlerName and body as strings.
-            view.evaluateJavascript("""
-            if (!window.webkit) window.webkit = {};
-            webkit.messageHandlers = new Proxy({}, {
-                get: (target, messageHandlerName, receiver) => ({
-                    postMessage: (body) => skipWebAndroidMessageHandler.postMessage(String(messageHandlerName), JSON.stringify(body))
-                })
-            });
-        """) { _ in logger.debug("Added webkit.messageHandlers") }
+    func recoverIfNeeded(for url: String) {
+        guard androidPreparedCosmeticPageURL != url else {
+            return
         }
-        for userScript in config.userScripts {
-            if userScript.webKitUserScript.injectionTime == .atDocumentStart {
-                let source = userScript.webKitUserScript.source
-                view.evaluateJavascript(source) { _ in
-                    logger.debug("Executed user script \(source)")
-                }
-            }
+        guard let pageURL = URL(string: url) else {
+            removeAllAndroidCosmeticScriptHandlers()
+            androidLifecycleCosmeticCSS = []
+            androidPreparedCosmeticPageURL = nil
+            return
         }
-        injectAndroidContentBlockerCSSIfNeeded(into: view)
-        webViewClient.onPageStarted(view, url, favicon)
+
+        if androidPreparedCosmeticPageURL != nil {
+            logger.info("Falling back to late Android cosmetic injection for \(pageURL.absoluteString)")
+        }
+        removeAllAndroidCosmeticScriptHandlers()
+        let fallbackPlan = fallbackAndroidCosmeticPlan(for: pageURL)
+        androidLifecycleCosmeticCSS = fallbackPlan.lifecycleCSS
+        androidPreparedCosmeticPageURL = pageURL.absoluteString
     }
 
-    /// Notify the host application to handle a SSL client certificate request.
-    override func onReceivedClientCertRequest(view: PlatformWebView, request: android.webkit.ClientCertRequest) {
-        logger.log("onReceivedClientCertRequest: \(request)")
-        webViewClient.onReceivedClientCertRequest(view, request)
+    func injectIfNeeded(into view: PlatformWebView) {
+        guard let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
+            cssRules: androidLifecycleCosmeticCSS,
+            styleID: "__skipweb_content_blockers",
+            frameScope: .mainFrameOnly
+        ) else {
+            clearCSS(in: view)
+            return
+        }
+
+        view.evaluateJavascript(injectionScript) { _ in
+            logger.debug("Injected Android content blocker CSS")
+        }
     }
 
-    /// Report web resource loading error to the host application.
-    override func onReceivedError(view: PlatformWebView, request: android.webkit.WebResourceRequest, error: android.webkit.WebResourceError) {
-        logger.log("onReceivedError: \(error)")
-        webViewClient.onReceivedError(view, request, error)
-    }
-
-    /// Notifies the host application that the WebView received an HTTP authentication request.
-    override func onReceivedHttpAuthRequest(view: PlatformWebView, handler: android.webkit.HttpAuthHandler, host: String, realm: String) {
-        logger.log("onReceivedHttpAuthRequest: \(handler) \(host) \(realm)")
-        webViewClient.onReceivedHttpAuthRequest(view, handler, host, realm)
+    func intercept(_ request: android.webkit.WebResourceRequest) -> android.webkit.WebResourceResponse? {
+        guard let provider, let requestURL = URL(string: request.url.toString()) else {
+            return nil
+        }
+        let headers = WebEngine.androidRequestHeaders(from: request)
+        let decision = provider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: requestURL,
+                mainDocumentURL: WebEngine.androidMainDocumentURL(
+                    for: request,
+                    requestURL: requestURL,
+                    headers: headers
+                ),
+                method: request.method,
+                headers: headers,
+                isForMainFrame: request.isForMainFrame,
+                hasGesture: request.hasGesture(),
+                isRedirect: WebEngine.androidRequestIsRedirect(request),
+                resourceTypeHint: WebEngine.androidResourceTypeHint(
+                    for: request,
+                    requestURL: requestURL,
+                    headers: headers
+                )
+            )
+        )
+        if case .block = decision {
+            return WebEngine.blockedAndroidResponse()
+        }
+        return nil
     }
 
     private func removeAllAndroidCosmeticScriptHandlers() {
@@ -2001,11 +2133,11 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     }
 
     private func androidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
-        guard let blocker = config.contentBlockers?.androidCosmeticBlocker else {
+        guard let provider else {
             return AndroidCosmeticInjectionPlan()
         }
         return WebEngine.androidCosmeticInjectionPlan(
-            rules: blocker.cosmetics(for: AndroidPageContext(url: pageURL)),
+            rules: provider.cosmeticRules(for: AndroidPageContext(url: pageURL)),
             pageURL: pageURL,
             isDocumentStartSupported: WebEngine.isAndroidDocumentStartScriptSupported()
         ) { message in
@@ -2014,11 +2146,11 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
     }
 
     private func fallbackAndroidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
-        guard let blocker = config.contentBlockers?.androidCosmeticBlocker else {
+        guard let provider else {
             return AndroidCosmeticInjectionPlan()
         }
         return WebEngine.androidRedirectFallbackCosmeticPlan(
-            rules: blocker.cosmetics(for: AndroidPageContext(url: pageURL)),
+            rules: provider.cosmeticRules(for: AndroidPageContext(url: pageURL)),
             pageURL: pageURL
         ) { message in
             logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
@@ -2053,155 +2185,288 @@ public class WebEngineDelegate : android.webkit.WebViewClient {
         return WebViewCompat.addDocumentStartJavaScript(view, script, allowedOriginRules)
     }
 
-    fileprivate func prepareAndroidCosmeticRules(for pageURL: URL, in view: PlatformWebView) {
-        removeAllAndroidCosmeticScriptHandlers()
-        let plan = androidCosmeticPlan(for: pageURL)
-        androidLifecycleCosmeticCSS = plan.lifecycleCSS
-
-        if WebEngine.isAndroidDocumentStartScriptSupported() {
-            for (index, rule) in plan.documentStartRules.enumerated() {
-                if let handler = registerAndroidDocumentStartCosmeticRule(rule, index: index, for: pageURL, in: view) {
-                    androidCosmeticScriptHandlers.append(handler)
-                }
-            }
-        }
-
-        androidPreparedCosmeticPageURL = pageURL.absoluteString
-    }
-
-    private func recoverAndroidCosmeticsIfNeeded(for url: String) {
-        guard androidPreparedCosmeticPageURL != url else {
-            return
-        }
-        guard let pageURL = URL(string: url) else {
-            removeAllAndroidCosmeticScriptHandlers()
-            androidLifecycleCosmeticCSS = []
-            androidPreparedCosmeticPageURL = nil
-            return
-        }
-
-        if androidPreparedCosmeticPageURL != nil {
-            logger.info("Falling back to late Android cosmetic injection for \(pageURL.absoluteString)")
-        }
-        removeAllAndroidCosmeticScriptHandlers()
-        let fallbackPlan = fallbackAndroidCosmeticPlan(for: pageURL)
-        androidLifecycleCosmeticCSS = fallbackPlan.lifecycleCSS
-        androidPreparedCosmeticPageURL = pageURL.absoluteString
-    }
-
-    private func clearAndroidContentBlockerCSS(in view: PlatformWebView) {
+    private func clearCSS(in view: PlatformWebView) {
         let removalScript = WebEngine.androidContentBlockerStyleRemovalScript(styleID: "__skipweb_content_blockers")
         view.evaluateJavascript(removalScript) { _ in
             logger.debug("Cleared Android content blocker CSS")
         }
     }
+}
 
-    private func injectAndroidContentBlockerCSSIfNeeded(into view: PlatformWebView) {
-        guard let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
-            cssRules: androidLifecycleCosmeticCSS,
-            styleID: "__skipweb_content_blockers",
-            frameScope: .mainFrameOnly
-        ) else {
-            clearAndroidContentBlockerCSS(in: view)
-            return
-        }
+final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
+    weak var engine: WebEngine?
+    var embeddedNavigationClient: android.webkit.WebViewClient?
+    var legacyNavigationDelegate: WebEngineDelegate?
 
-        view.evaluateJavascript(injectionScript) { _ in
-            logger.debug("Injected Android content blocker CSS")
-        }
+    init(engine: WebEngine) {
+        self.engine = engine
+        super.init()
     }
 
-    /// Notify the host application that an HTTP error has been received from the server while loading a resource.
+    private var config: WebEngineConfiguration? {
+        engine?.configuration
+    }
+
+    override func doUpdateVisitedHistory(view: PlatformWebView, url: String, isReload: Bool) {
+        logger.log("application")
+        embeddedNavigationClient?.doUpdateVisitedHistory(view, url, isReload)
+        legacyNavigationDelegate?.doUpdateVisitedHistory(view, url, isReload)
+    }
+
+    override func onFormResubmission(view: PlatformWebView, dontResend: android.os.Message, resend: android.os.Message) {
+        logger.log("onFormResubmission")
+        embeddedNavigationClient?.onFormResubmission(view, dontResend, resend)
+        legacyNavigationDelegate?.onFormResubmission(view, dontResend, resend)
+    }
+
+    override func onLoadResource(view: PlatformWebView, url: String) {
+        logger.log("onLoadResource: \(url)")
+        embeddedNavigationClient?.onLoadResource(view, url)
+        legacyNavigationDelegate?.onLoadResource(view, url)
+    }
+
+    override func onPageCommitVisible(view: PlatformWebView, url: String) {
+        logger.log("onPageCommitVisible: \(url)")
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        engine?.androidContentBlockerController.injectIfNeeded(into: view)
+        embeddedNavigationClient?.onPageCommitVisible(view, url)
+        legacyNavigationDelegate?.onPageCommitVisible(view, url)
+    }
+
+    override func onPageFinished(view: PlatformWebView, url: String) {
+        logger.log("onPageFinished: \(url)")
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        engine?.androidContentBlockerController.injectIfNeeded(into: view)
+        for userScript in config?.userScripts ?? [] {
+            if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
+                let source = userScript.webKitUserScript.source
+                view.evaluateJavascript(source) { _ in
+                    logger.debug("Executed user script \(source)")
+                }
+            }
+        }
+        embeddedNavigationClient?.onPageFinished(view, url)
+        if let engine {
+            engine.androidNavigationDelegate?.webEngineDidFinishNavigation(engine)
+        }
+        legacyNavigationDelegate?.onPageFinished(view, url)
+        engine?.completeAndroidPageLoad(.success(()))
+    }
+
+    override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
+        logger.log("onPageStarted: \(url)")
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        if !(config?.messageHandlers.isEmpty ?? true) {
+            view.evaluateJavascript("""
+            if (!window.webkit) window.webkit = {};
+            webkit.messageHandlers = new Proxy({}, {
+                get: (target, messageHandlerName, receiver) => ({
+                    postMessage: (body) => skipWebAndroidMessageHandler.postMessage(String(messageHandlerName), JSON.stringify(body))
+                })
+            });
+        """) { _ in logger.debug("Added webkit.messageHandlers") }
+        }
+        for userScript in config?.userScripts ?? [] {
+            if userScript.webKitUserScript.injectionTime == .atDocumentStart {
+                let source = userScript.webKitUserScript.source
+                view.evaluateJavascript(source) { _ in
+                    logger.debug("Executed user script \(source)")
+                }
+            }
+        }
+        engine?.androidContentBlockerController.injectIfNeeded(into: view)
+        embeddedNavigationClient?.onPageStarted(view, url, favicon)
+        if let engine {
+            engine.androidNavigationDelegate?.webEngineDidCommitNavigation(engine)
+        }
+        legacyNavigationDelegate?.onPageStarted(view, url, favicon)
+    }
+
+    override func onReceivedClientCertRequest(view: PlatformWebView, request: android.webkit.ClientCertRequest) {
+        logger.log("onReceivedClientCertRequest: \(request)")
+        embeddedNavigationClient?.onReceivedClientCertRequest(view, request)
+        legacyNavigationDelegate?.onReceivedClientCertRequest(view, request)
+    }
+
+    override func onReceivedError(view: PlatformWebView, request: android.webkit.WebResourceRequest, error: android.webkit.WebResourceError) {
+        logger.log("onReceivedError: \(error)")
+        embeddedNavigationClient?.onReceivedError(view, request, error)
+        let loadError = WebLoadError(msg: String(error.description), code: error.errorCode)
+        if let engine {
+            engine.androidNavigationDelegate?.webEngine(engine, didFailNavigation: loadError)
+        }
+        legacyNavigationDelegate?.onReceivedError(view, request, error)
+        engine?.completeAndroidPageLoad(.failure(loadError))
+    }
+
+    override func onReceivedHttpAuthRequest(view: PlatformWebView, handler: android.webkit.HttpAuthHandler, host: String, realm: String) {
+        logger.log("onReceivedHttpAuthRequest: \(handler) \(host) \(realm)")
+        embeddedNavigationClient?.onReceivedHttpAuthRequest(view, handler, host, realm)
+        legacyNavigationDelegate?.onReceivedHttpAuthRequest(view, handler, host, realm)
+    }
+
     override func onReceivedHttpError(view: PlatformWebView, request: android.webkit.WebResourceRequest, errorResponse: android.webkit.WebResourceResponse) {
         logger.log("onReceivedHttpError: \(request) \(errorResponse)")
-        webViewClient.onReceivedHttpError(view, request, errorResponse)
+        embeddedNavigationClient?.onReceivedHttpError(view, request, errorResponse)
+        legacyNavigationDelegate?.onReceivedHttpError(view, request, errorResponse)
     }
 
-    /// Notify the host application that a request to automatically log in the user has been processed.
-//    override func onReceivedLoginRequest(view: PlatformWebView, realm: String, account: String, args: String) {
-//        webViewClient.onReceivedLoginRequest(view, realm, account, args)
-//    }
-
-    /// Notifies the host application that an SSL error occurred while loading a resource.
     override func onReceivedSslError(view: PlatformWebView, handler: android.webkit.SslErrorHandler, error: android.net.http.SslError) {
         logger.log("onReceivedSslError: \(error)")
-        webViewClient.onReceivedSslError(view, handler, error)
+        embeddedNavigationClient?.onReceivedSslError(view, handler, error)
+        legacyNavigationDelegate?.onReceivedSslError(view, handler, error)
     }
 
-    /// Notify host application that the given WebView's render process has exited.
     override func onRenderProcessGone(view: PlatformWebView, detail: android.webkit.RenderProcessGoneDetail) -> Bool {
         logger.log("onRenderProcessGone: \(detail)")
-        return webViewClient.onRenderProcessGone(view, detail)
+        let embeddedHandled = embeddedNavigationClient?.onRenderProcessGone(view, detail) ?? false
+        let legacyHandled = legacyNavigationDelegate?.onRenderProcessGone(view, detail) ?? false
+        return embeddedHandled || legacyHandled
     }
 
-    /// Notify the host application that a loading URL has been flagged by Safe Browsing.
     override func onSafeBrowsingHit(view: PlatformWebView, request: android.webkit.WebResourceRequest, threatType: Int, callback: android.webkit.SafeBrowsingResponse) {
         logger.log("onSafeBrowsingHit: \(request)")
-        webViewClient.onSafeBrowsingHit(view, request, threatType, callback)
+        embeddedNavigationClient?.onSafeBrowsingHit(view, request, threatType, callback)
+        legacyNavigationDelegate?.onSafeBrowsingHit(view, request, threatType, callback)
     }
 
-    /// Notify the host application that the scale applied to the WebView has changed.
     override func onScaleChanged(view: PlatformWebView, oldScale: Float, newScale: Float) {
         logger.log("onScaleChanged: \(oldScale) \(newScale)")
-        webViewClient.onScaleChanged(view, oldScale, newScale)
+        embeddedNavigationClient?.onScaleChanged(view, oldScale, newScale)
+        legacyNavigationDelegate?.onScaleChanged(view, oldScale, newScale)
     }
 
-    /// Notify the host application that a key was not handled by the WebView.
     override func onUnhandledKeyEvent(view: PlatformWebView, event: android.view.KeyEvent) {
         logger.log("onUnhandledKeyEvent: \(event)")
-        webViewClient.onUnhandledKeyEvent(view, event)
+        embeddedNavigationClient?.onUnhandledKeyEvent(view, event)
+        legacyNavigationDelegate?.onUnhandledKeyEvent(view, event)
     }
 
-    /// Notify the host application of a resource request and allow the application to return the data.
     public override func shouldInterceptRequest(view: PlatformWebView, request: android.webkit.WebResourceRequest) -> android.webkit.WebResourceResponse? {
         logger.log("shouldInterceptRequest: \(request.url)")
         let scheme: String = request.url?.scheme ?? ""
-        if let handler = config.schemeHandlers[scheme] {
+        if let handler = config?.schemeHandlers[scheme] {
             return handler.interceptRequest(view: view, request: request)
         }
-        if let blocker = config.contentBlockers?.androidRequestBlocker,
-           let requestURL = URL(string: request.url.toString()) {
-            let headers = WebEngine.androidRequestHeaders(from: request)
-            let decision = blocker.decision(
-                for: AndroidBlockableRequest(
-                    url: requestURL,
-                    mainDocumentURL: WebEngine.androidMainDocumentURL(
-                        for: request,
-                        requestURL: requestURL,
-                        headers: headers
-                    ),
-                    method: request.method,
-                    headers: headers,
-                    isForMainFrame: request.isForMainFrame,
-                    hasGesture: request.hasGesture(),
-                    isRedirect: WebEngine.androidRequestIsRedirect(request),
-                    resourceTypeHint: WebEngine.androidResourceTypeHint(
-                        for: request,
-                        requestURL: requestURL,
-                        headers: headers
-                    )
-                )
-            )
-            if case .block = decision {
-                return WebEngine.blockedAndroidResponse()
-            }
+        if let response = engine?.androidContentBlockerController.intercept(request) {
+            return response
         }
-        return webViewClient.shouldInterceptRequest(view, request)
+        if let response = legacyNavigationDelegate?.shouldInterceptRequest(view, request) {
+            return response
+        }
+        return embeddedNavigationClient?.shouldInterceptRequest(view, request)
     }
 
-    /// Give the host application a chance to handle the key event synchronously.
     override func shouldOverrideKeyEvent(view: PlatformWebView, event: android.view.KeyEvent) -> Bool {
         logger.log("shouldOverrideKeyEvent: \(event)")
-        return webViewClient.shouldOverrideKeyEvent(view, event)
+        if embeddedNavigationClient?.shouldOverrideKeyEvent(view, event) == true {
+            return true
+        }
+        if legacyNavigationDelegate?.shouldOverrideKeyEvent(view, event) == true {
+            return true
+        }
+        return false
     }
 
-    /// Give the host application a chance to take control when a URL is about to be loaded in the current WebView.
     override func shouldOverrideUrlLoading(view: PlatformWebView, request: android.webkit.WebResourceRequest) -> Bool {
         logger.log("shouldOverrideUrlLoading: \(request.url)")
-        if request.isForMainFrame, let url = URL(string: request.url.toString()) {
-            prepareAndroidCosmeticRules(for: url, in: view)
+        let mainFrameURL = request.isForMainFrame ? URL(string: request.url.toString()) : nil
+        if let engine, let url = mainFrameURL {
+            engine.androidContentBlockerController.prepare(for: url, in: view)
         }
-        return webViewClient.shouldOverrideUrlLoading(view, request)
+        if embeddedNavigationClient?.shouldOverrideUrlLoading(view, request) == true {
+            return true
+        }
+        if let engine, let url = mainFrameURL {
+            if engine.androidNavigationDelegate?.webEngine(engine, shouldOverrideURLLoading: url) == true {
+                return true
+            }
+        }
+        return legacyNavigationDelegate?.shouldOverrideUrlLoading(view, request) ?? false
+    }
+}
+
+// SKIP @nobridge
+public class WebEngineDelegate : android.webkit.WebViewClient {
+    let config: WebEngineConfiguration
+    let webViewClient: android.webkit.WebViewClient
+
+    override init(config: WebEngineConfiguration, webViewClient: android.webkit.WebViewClient = android.webkit.WebViewClient()) {
+        super.init()
+        self.config = config
+        self.webViewClient = webViewClient
+    }
+
+    override func doUpdateVisitedHistory(view: PlatformWebView, url: String, isReload: Bool) {
+        webViewClient.doUpdateVisitedHistory(view, url, isReload)
+    }
+
+    override func onFormResubmission(view: PlatformWebView, dontResend: android.os.Message, resend: android.os.Message) {
+        webViewClient.onFormResubmission(view, dontResend, resend)
+    }
+
+    override func onLoadResource(view: PlatformWebView, url: String) {
+        webViewClient.onLoadResource(view, url)
+    }
+
+    override func onPageCommitVisible(view: PlatformWebView, url: String) {
+        webViewClient.onPageCommitVisible(view, url)
+    }
+
+    override func onPageFinished(view: PlatformWebView, url: String) {
+        webViewClient.onPageFinished(view, url)
+    }
+
+    override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
+        webViewClient.onPageStarted(view, url, favicon)
+    }
+
+    override func onReceivedClientCertRequest(view: PlatformWebView, request: android.webkit.ClientCertRequest) {
+        webViewClient.onReceivedClientCertRequest(view, request)
+    }
+
+    override func onReceivedError(view: PlatformWebView, request: android.webkit.WebResourceRequest, error: android.webkit.WebResourceError) {
+        webViewClient.onReceivedError(view, request, error)
+    }
+
+    override func onReceivedHttpAuthRequest(view: PlatformWebView, handler: android.webkit.HttpAuthHandler, host: String, realm: String) {
+        webViewClient.onReceivedHttpAuthRequest(view, handler, host, realm)
+    }
+
+    override func onReceivedHttpError(view: PlatformWebView, request: android.webkit.WebResourceRequest, errorResponse: android.webkit.WebResourceResponse) {
+        webViewClient.onReceivedHttpError(view, request, errorResponse)
+    }
+
+    override func onReceivedSslError(view: PlatformWebView, handler: android.webkit.SslErrorHandler, error: android.net.http.SslError) {
+        webViewClient.onReceivedSslError(view, handler, error)
+    }
+
+    override func onRenderProcessGone(view: PlatformWebView, detail: android.webkit.RenderProcessGoneDetail) -> Bool {
+        webViewClient.onRenderProcessGone(view, detail)
+    }
+
+    override func onSafeBrowsingHit(view: PlatformWebView, request: android.webkit.WebResourceRequest, threatType: Int, callback: android.webkit.SafeBrowsingResponse) {
+        webViewClient.onSafeBrowsingHit(view, request, threatType, callback)
+    }
+
+    override func onScaleChanged(view: PlatformWebView, oldScale: Float, newScale: Float) {
+        webViewClient.onScaleChanged(view, oldScale, newScale)
+    }
+
+    override func onUnhandledKeyEvent(view: PlatformWebView, event: android.view.KeyEvent) {
+        webViewClient.onUnhandledKeyEvent(view, event)
+    }
+
+    public override func shouldInterceptRequest(view: PlatformWebView, request: android.webkit.WebResourceRequest) -> android.webkit.WebResourceResponse? {
+        webViewClient.shouldInterceptRequest(view, request)
+    }
+
+    override func shouldOverrideKeyEvent(view: PlatformWebView, event: android.view.KeyEvent) -> Bool {
+        webViewClient.shouldOverrideKeyEvent(view, event)
+    }
+
+    override func shouldOverrideUrlLoading(view: PlatformWebView, request: android.webkit.WebResourceRequest) -> Bool {
+        webViewClient.shouldOverrideUrlLoading(view, request)
     }
 }
 #else
@@ -2494,6 +2759,7 @@ public extension SkipWebUIDelegate {
     public var messageHandlers: [String: ((WebViewMessage) async -> Void)]
     public var schemeHandlers: [String: URLSchemeHandler]
     public var uiDelegate: (any SkipWebUIDelegate)?
+    public var navigationDelegate: (any SkipWebNavigationDelegate)?
     public var contentBlockers: WebContentBlockerConfiguration?
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
 
@@ -2517,6 +2783,7 @@ public extension SkipWebUIDelegate {
                 messageHandlers: [String: ((WebViewMessage) async -> Void)] = [:],
                 schemeHandlers: [String: URLSchemeHandler] = [:],
                 uiDelegate: (any SkipWebUIDelegate)? = nil,
+                navigationDelegate: (any SkipWebNavigationDelegate)? = nil,
                 contentBlockers: WebContentBlockerConfiguration? = nil) {
         self.javaScriptEnabled = javaScriptEnabled
         self.javaScriptCanOpenWindowsAutomatically = javaScriptCanOpenWindowsAutomatically
@@ -2533,6 +2800,7 @@ public extension SkipWebUIDelegate {
         self.messageHandlers = messageHandlers
         self.schemeHandlers = schemeHandlers
         self.uiDelegate = uiDelegate
+        self.navigationDelegate = navigationDelegate
         self.contentBlockers = contentBlockers
     }
 
@@ -2553,6 +2821,7 @@ public extension SkipWebUIDelegate {
             messageHandlers: messageHandlers,
             schemeHandlers: schemeHandlers,
             uiDelegate: uiDelegate,
+            navigationDelegate: navigationDelegate,
             contentBlockers: contentBlockers
         )
         #if SKIP
@@ -2923,20 +3192,36 @@ fileprivate enum WebContentBlockerStore {
         description: String,
         operation: (@escaping (T?, Error?) -> Void) -> Void
     ) -> Result<T?, Error> {
+        let lock = NSLock()
+        let semaphore = DispatchSemaphore(value: 0)
         var result: Result<T?, Error>?
         operation { value, error in
+            let callbackResult: Result<T?, Error>
             if let error {
-                result = .failure(error)
+                callbackResult = .failure(error)
             } else {
-                result = .success(value)
+                callbackResult = .success(value)
             }
+            lock.lock()
+            result = callbackResult
+            lock.unlock()
+            semaphore.signal()
         }
 
-        let deadline = Date().addingTimeInterval(10.0)
-        while result == nil && deadline.timeIntervalSinceNow > 0 {
+        let deadline = Date().addingTimeInterval(contentBlockerCallbackTimeout)
+        while deadline.timeIntervalSinceNow > 0 {
+            if semaphore.wait(timeout: .now()) == .success {
+                lock.lock()
+                defer { lock.unlock() }
+                return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
+            }
+
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.01))
         }
 
+        lock.lock()
+        defer { lock.unlock() }
         return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
     }
 
@@ -2944,21 +3229,52 @@ fileprivate enum WebContentBlockerStore {
         description: String,
         operation: (@escaping (Error?) -> Void) -> Void
     ) -> Result<Void, Error> {
+        let lock = NSLock()
+        let semaphore = DispatchSemaphore(value: 0)
         var result: Result<Void, Error>?
         operation { error in
+            let callbackResult: Result<Void, Error>
             if let error {
-                result = .failure(error)
+                callbackResult = .failure(error)
             } else {
-                result = .success(())
+                callbackResult = .success(())
             }
+            lock.lock()
+            result = callbackResult
+            lock.unlock()
+            semaphore.signal()
         }
 
-        let deadline = Date().addingTimeInterval(10.0)
-        while result == nil && deadline.timeIntervalSinceNow > 0 {
+        let deadline = Date().addingTimeInterval(contentBlockerCallbackTimeout)
+        while deadline.timeIntervalSinceNow > 0 {
+            if semaphore.wait(timeout: .now()) == .success {
+                lock.lock()
+                defer { lock.unlock() }
+                return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
+            }
+
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
+            RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.01))
         }
 
+        lock.lock()
+        defer { lock.unlock() }
         return result ?? .failure(WebContentBlockerError.operationTimedOut(description))
+    }
+
+    private static var contentBlockerCallbackTimeout: TimeInterval {
+        let environment = ProcessInfo.processInfo.environment
+        if let rawValue = environment["SKIPWEB_CONTENT_BLOCKER_TIMEOUT"],
+           let timeout = TimeInterval(rawValue),
+           timeout > 0 {
+            return timeout
+        }
+
+        if environment["GITHUB_ACTIONS"] == "true" || environment["CI"] == "true" {
+            return 60.0
+        }
+
+        return 10.0
     }
 
     private static func hexString<D: Digest>(_ digest: D) -> String {

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -152,6 +152,7 @@ public enum WebProfileError: Error, Equatable {
 
 public struct WebContentBlockerConfiguration {
     public var iOSRuleListPaths: [String]
+    public var whitelistedDomains: [String]
     public var androidMode: AndroidContentBlockingMode
     @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
     public var androidRequestBlocker: (any AndroidRequestBlocker)?
@@ -160,11 +161,13 @@ public struct WebContentBlockerConfiguration {
 
     public init(
         iOSRuleListPaths: [String] = [],
+        whitelistedDomains: [String] = [],
         androidMode: AndroidContentBlockingMode = .disabled,
         androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
         androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
     ) {
         self.iOSRuleListPaths = iOSRuleListPaths
+        self.whitelistedDomains = whitelistedDomains
         self.androidMode = androidMode
         self.androidRequestBlocker = androidRequestBlocker
         self.androidCosmeticBlocker = androidCosmeticBlocker
@@ -356,25 +359,75 @@ fileprivate struct LegacyAndroidContentBlockingProvider: AndroidContentBlockingP
     }
 }
 
+fileprivate struct WhitelistedAndroidContentBlockingProvider: AndroidContentBlockingProvider {
+    let provider: any AndroidContentBlockingProvider
+    let whitelistedDomains: [String]
+
+    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+        if isWhitelisted(request: request) {
+            return .allow
+        }
+        return provider.requestDecision(for: request)
+    }
+
+    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        if WebContentBlockerConfiguration.matchesWhitelistedDomain(page.host, in: whitelistedDomains) {
+            return []
+        }
+        return provider.cosmeticRules(for: page)
+    }
+
+    private func isWhitelisted(request: AndroidBlockableRequest) -> Bool {
+        if WebContentBlockerConfiguration.matchesWhitelistedURL(request.mainDocumentURL, in: whitelistedDomains) {
+            return true
+        }
+        if request.isForMainFrame {
+            return WebContentBlockerConfiguration.matchesWhitelistedURL(request.url, in: whitelistedDomains)
+        }
+        return false
+    }
+}
+
 extension WebContentBlockerConfiguration {
+    var normalizedWhitelistedDomains: [String] {
+        Self.normalizedWhitelistedDomains(from: whitelistedDomains)
+    }
+
     var hasLegacyAndroidHooks: Bool {
         androidRequestBlocker != nil || androidCosmeticBlocker != nil
     }
 
     var effectiveAndroidMode: AndroidContentBlockingMode {
+        let baseMode: AndroidContentBlockingMode
         switch androidMode {
         case .disabled:
             if hasLegacyAndroidHooks {
-                return .custom(
+                baseMode = .custom(
                     LegacyAndroidContentBlockingProvider(
                         requestBlocker: androidRequestBlocker,
                         cosmeticBlocker: androidCosmeticBlocker
                     )
                 )
+            } else {
+                baseMode = .disabled
             }
-            return .disabled
         case .custom:
-            return androidMode
+            baseMode = androidMode
+        }
+
+        switch baseMode {
+        case .disabled:
+            return .disabled
+        case .custom(let provider):
+            guard !normalizedWhitelistedDomains.isEmpty else {
+                return .custom(provider)
+            }
+            return .custom(
+                WhitelistedAndroidContentBlockingProvider(
+                    provider: provider,
+                    whitelistedDomains: normalizedWhitelistedDomains
+                )
+            )
         }
     }
 
@@ -386,6 +439,78 @@ extension WebContentBlockerConfiguration {
             return provider
         }
     }
+
+    static func normalizedWhitelistedDomains(from domains: [String]) -> [String] {
+        Array(
+            Set(
+                domains.compactMap { domain in
+                    let trimmed = domain.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+            )
+        ).sorted()
+    }
+
+    static func matchesWhitelistedURL(_ url: URL?, in domains: [String]) -> Bool {
+        matchesWhitelistedDomain(url?.host, in: domains)
+    }
+
+    static func matchesWhitelistedDomain(_ host: String?, in domains: [String]) -> Bool {
+        guard let normalizedHost = host?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !normalizedHost.isEmpty else {
+            return false
+        }
+
+        for domain in domains {
+            if domain.hasPrefix("*.") {
+                let suffix = String(domain.dropFirst(2))
+                guard !suffix.isEmpty else {
+                    continue
+                }
+                if normalizedHost.count > suffix.count && normalizedHost.hasSuffix(".\(suffix)") {
+                    return true
+                }
+            } else if normalizedHost == domain {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    #if !SKIP
+    func augmentedIOSRuleListContent(_ content: String) -> String {
+        Self.augmentedIOSRuleListContent(content, whitelistedDomains: normalizedWhitelistedDomains)
+    }
+
+    static func augmentedIOSRuleListContent(_ content: String, whitelistedDomains: [String]) -> String {
+        guard !whitelistedDomains.isEmpty,
+              let data = content.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data),
+              var rules = jsonObject as? [[String: Any]] else {
+            return content
+        }
+
+        rules.append([
+            "comment": "user-injected domain exemptions (whitelisted domains)",
+            "trigger": [
+                "url-filter": ".*",
+                "if-domain": whitelistedDomains
+            ],
+            "action": [
+                "type": "ignore-previous-rules"
+            ]
+        ])
+
+        guard JSONSerialization.isValidJSONObject(rules),
+              let augmentedData = try? JSONSerialization.data(withJSONObject: rules, options: [.sortedKeys]),
+              let augmentedContent = String(data: augmentedData, encoding: .utf8) else {
+            return content
+        }
+
+        return augmentedContent
+    }
+    #endif
 }
 
 public enum WebContentBlockerError: Error, Equatable, LocalizedError {
@@ -2942,7 +3067,10 @@ public extension SkipWebUIDelegate {
             return []
         }
 
-        let prepared = await WebContentBlockerStore.prepareRuleLists(from: contentBlockers.iOSRuleListPaths)
+        let prepared = await WebContentBlockerStore.prepareRuleLists(
+            from: contentBlockers.iOSRuleListPaths,
+            whitelistedDomains: contentBlockers.normalizedWhitelistedDomains
+        )
         contentBlockerSetupErrors = prepared.errors
         for ruleList in prepared.ruleLists {
             userContentController.add(ruleList)
@@ -3012,10 +3140,10 @@ struct WebContentBlockerDiagnostics: Equatable {
     var errors: [WebContentBlockerError] = []
 }
 
-@MainActor enum WebContentBlockerDebug {
-    static var diagnostics: WebContentBlockerDiagnostics {
-        WebContentBlockerStore.diagnostics
-    }
+    @MainActor enum WebContentBlockerDebug {
+        static var diagnostics: WebContentBlockerDiagnostics {
+            WebContentBlockerStore.diagnostics
+        }
 
     static func resetDiagnostics() {
         WebContentBlockerStore.diagnostics = WebContentBlockerDiagnostics()
@@ -3027,6 +3155,13 @@ struct WebContentBlockerDiagnostics: Equatable {
 
     static func clearPersistentState() throws {
         try WebContentBlockerStore.clearPersistentState()
+    }
+
+    static func augmentedRuleListContent(_ content: String, whitelistedDomains: [String]) -> String {
+        WebContentBlockerConfiguration.augmentedIOSRuleListContent(
+            content,
+            whitelistedDomains: WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: whitelistedDomains)
+        )
     }
 }
 
@@ -3049,11 +3184,12 @@ fileprivate enum WebContentBlockerStore {
     private static let storeDirectoryName = "RuleListStore"
     private static let metadataVersion = 1
 
-    static func prepareRuleLists(from sourcePaths: [String]) async -> PreparedContentBlockerRuleLists {
+    static func prepareRuleLists(from sourcePaths: [String], whitelistedDomains: [String]) async -> PreparedContentBlockerRuleLists {
         var ruleLists: [WKContentRuleList] = []
         var errors: [WebContentBlockerError] = []
 
         let normalizedSourcePaths = normalizedPaths(from: sourcePaths)
+        let normalizedWhitelistedDomains = WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: whitelistedDomains)
         guard !normalizedSourcePaths.isEmpty else {
             diagnostics.errors = []
             return PreparedContentBlockerRuleLists(ruleLists: [], errors: [])
@@ -3084,7 +3220,12 @@ fileprivate enum WebContentBlockerStore {
                 continue
             }
 
-            let identifier = ruleListIdentifier(for: sourcePath, contentData: fileData)
+            let augmentedContent = WebContentBlockerConfiguration.augmentedIOSRuleListContent(
+                content,
+                whitelistedDomains: normalizedWhitelistedDomains
+            )
+            let augmentedContentData = Data(augmentedContent.utf8)
+            let identifier = ruleListIdentifier(for: sourcePath, contentData: augmentedContentData)
             nextIdentifiersBySourcePath[sourcePath] = identifier
             staleIdentifiers.remove(identifier)
 
@@ -3094,7 +3235,7 @@ fileprivate enum WebContentBlockerStore {
                 continue
             }
 
-            if let compiledRuleList = await compileRuleList(identifier: identifier, content: content, sourcePath: sourcePath, in: store, errors: &errors) {
+            if let compiledRuleList = await compileRuleList(identifier: identifier, content: augmentedContent, sourcePath: sourcePath, in: store, errors: &errors) {
                 ruleLists.append(compiledRuleList)
                 diagnostics.compiledIdentifiers.append(identifier)
             }

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -175,17 +175,14 @@ public struct WebContentBlockerConfiguration {
 }
 
 public protocol AndroidContentBlockingProvider {
+    var persistentCosmeticRules: [AndroidCosmeticRule] { get }
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
+    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
 }
 
 public extension AndroidContentBlockingProvider {
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
         .allow
-    }
-
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-        []
     }
 }
 
@@ -350,11 +347,15 @@ fileprivate struct LegacyAndroidContentBlockingProvider: AndroidContentBlockingP
     let requestBlocker: (any AndroidRequestBlocker)?
     let cosmeticBlocker: (any AndroidCosmeticBlocker)?
 
+    var persistentCosmeticRules: [AndroidCosmeticRule] {
+        []
+    }
+
     func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
         requestBlocker?.decision(for: request) ?? .allow
     }
 
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
         cosmeticBlocker?.cosmetics(for: page) ?? []
     }
 }
@@ -370,11 +371,12 @@ fileprivate struct WhitelistedAndroidContentBlockingProvider: AndroidContentBloc
         return provider.requestDecision(for: request)
     }
 
-    func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-        if WebContentBlockerConfiguration.matchesWhitelistedDomain(page.host, in: whitelistedDomains) {
-            return []
-        }
-        return provider.cosmeticRules(for: page)
+    var persistentCosmeticRules: [AndroidCosmeticRule] {
+        provider.persistentCosmeticRules
+    }
+
+    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+        provider.navigationCosmeticRules(for: page)
     }
 
     private func isWhitelisted(request: AndroidBlockableRequest) -> Bool {
@@ -1247,7 +1249,7 @@ extension WebCookie {
 
         let userContentController = webView.configuration.userContentController
         iosContentBlockerSetupTask = Task { @MainActor [configuration, weak self] in
-            let errors = await configuration.installContentBlockers(into: userContentController)
+            let errors = await configuration.installPreparedContentBlockers(into: userContentController)
             self?.contentBlockerSetupErrors = errors
             return errors
         }
@@ -1935,6 +1937,29 @@ extension WebCookie {
         #endif
     }
 
+    fileprivate static func appendAndroidDocumentStartRule(
+        _ rule: AndroidCosmeticRule,
+        to batchedRules: inout [AndroidCosmeticRule]
+    ) {
+        var matchingIndex: Int?
+        for index in batchedRules.indices {
+            let existingRule = batchedRules[index]
+            if existingRule.frameScope == rule.frameScope &&
+                existingRule.preferredTiming == rule.preferredTiming &&
+                existingRule.urlFilterPattern == rule.urlFilterPattern &&
+                existingRule.allowedOriginRules == rule.allowedOriginRules {
+                matchingIndex = index
+                break
+            }
+        }
+
+        if let matchingIndex {
+            batchedRules[matchingIndex].css.append(contentsOf: rule.css)
+        } else {
+            batchedRules.append(rule)
+        }
+    }
+
     static func androidCosmeticInjectionPlan(
         rules: [AndroidCosmeticRule],
         pageURL: URL,
@@ -1955,7 +1980,7 @@ extension WebCookie {
                     var normalizedRule = rule
                     normalizedRule.css = normalizedCSS
                     normalizedRule.allowedOriginRules = normalizedAndroidAllowedOriginRules(rule.allowedOriginRules)
-                    plan.documentStartRules.append(normalizedRule)
+                    appendAndroidDocumentStartRule(normalizedRule, to: &plan.documentStartRules)
                 } else if rule.frameScope == .mainFrameOnly,
                           androidAllowedOriginRulesMatchPage(rule.allowedOriginRules, pageURL: pageURL),
                           androidURLFilterPatternMatchesPage(rule.urlFilterPattern, pageURL: pageURL) {
@@ -2220,11 +2245,37 @@ extension WebEngine {
 
 
 #if SKIP
+fileprivate struct AndroidDocumentStartPlanRegistration {
+    let handlers: [ScriptHandler]
+    let styleIDs: [String]
+}
+
+fileprivate struct AndroidDocumentStartRuleRegistration {
+    let handler: ScriptHandler
+    let styleID: String
+}
+
 final class AndroidContentBlockerController {
     let config: WebEngineConfiguration
-    private var androidCosmeticScriptHandlers: [ScriptHandler] = []
-    private var androidLifecycleCosmeticCSS: [String] = []
+    // Think of persistent rules as a baseline installed once per WebView and reused
+    // until the provider says that baseline has changed.
+    private var persistentCosmeticScriptHandlers: [ScriptHandler] = []
+    private var persistentDocumentStartStyleIDs: [String] = []
+    private var persistentLifecycleCosmeticCSS: [String] = []
+    private var installedPersistentRules: [AndroidCosmeticRule] = []
+
+    // Navigation rules are the per-page delta. They may change on every main-frame
+    // navigation, so we track and refresh them separately from the persistent baseline.
+    private var navigationCosmeticScriptHandlers: [ScriptHandler] = []
+    private var navigationDocumentStartStyleIDs: [String] = []
+    private var navigationLifecycleCosmeticCSS: [String] = []
+    private var installedNavigationRules: [AndroidCosmeticRule] = []
     private var androidPreparedCosmeticPageURL: String?
+
+    private let persistentDocumentStartStyleIDPrefix = "__skipweb_content_blockers_persistent"
+    private let navigationDocumentStartStyleIDPrefix = "__skipweb_content_blockers_navigation"
+    private let persistentLifecycleStyleID = "__skipweb_content_blockers_persistent"
+    private let navigationLifecycleStyleID = "__skipweb_content_blockers_navigation"
 
     init(config: WebEngineConfiguration) {
         self.config = config
@@ -2235,54 +2286,203 @@ final class AndroidContentBlockerController {
     }
 
     func prepare(for pageURL: URL, in view: PlatformWebView) {
-        removeAllAndroidCosmeticScriptHandlers()
-        let plan = androidCosmeticPlan(for: pageURL)
-        androidLifecycleCosmeticCSS = plan.lifecycleCSS
+        let prepareStartedAt = currentMilliseconds()
+        let documentStartSupported = WebEngine.isAndroidDocumentStartScriptSupported()
+        let isWhitelisted = isWhitelisted(pageURL: pageURL)
+        let desiredPersistentRules = desiredPersistentRules(for: pageURL, isWhitelisted: isWhitelisted)
 
-        if WebEngine.isAndroidDocumentStartScriptSupported() {
-            for (index, rule) in plan.documentStartRules.enumerated() {
-                if let handler = registerAndroidDocumentStartCosmeticRule(rule, index: index, for: pageURL, in: view) {
-                    androidCosmeticScriptHandlers.append(handler)
-                }
-            }
+        let cosmeticQueryStartedAt = currentMilliseconds()
+        let desiredNavigationRules = desiredNavigationRules(for: pageURL, isWhitelisted: isWhitelisted)
+        let cosmeticQueryMilliseconds = currentMilliseconds() - cosmeticQueryStartedAt
+
+        let persistentPlanStartedAt = currentMilliseconds()
+        let persistentPlan = WebEngine.androidCosmeticInjectionPlan(
+            rules: desiredPersistentRules,
+            pageURL: pageURL,
+            isDocumentStartSupported: documentStartSupported
+        ) { message in
+            logger.warning("\(message) for \(pageURL.absoluteString)")
         }
+        let persistentPlanMilliseconds = currentMilliseconds() - persistentPlanStartedAt
+
+        let navigationPlanStartedAt = currentMilliseconds()
+        let navigationPlan = WebEngine.androidCosmeticInjectionPlan(
+            rules: desiredNavigationRules,
+            pageURL: pageURL,
+            isDocumentStartSupported: documentStartSupported
+        ) { message in
+            logger.warning("\(message) for \(pageURL.absoluteString)")
+        }
+        let navigationPlanMilliseconds = currentMilliseconds() - navigationPlanStartedAt
+
+        persistentLifecycleCosmeticCSS = persistentPlan.lifecycleCSS
+        navigationLifecycleCosmeticCSS = navigationPlan.lifecycleCSS
+
+        let persistentChanged = desiredPersistentRules != installedPersistentRules
+        let navigationChanged = desiredNavigationRules != installedNavigationRules
+
+        let persistentRegisterStartedAt = currentMilliseconds()
+        var removedPersistentHandlerCount = 0
+        var registeredPersistentHandlerCount = 0
+        if persistentChanged {
+            removedPersistentHandlerCount = persistentCosmeticScriptHandlers.count
+            removeDocumentStartRegistrations(
+                handlers: &persistentCosmeticScriptHandlers,
+                styleIDs: &persistentDocumentStartStyleIDs
+            )
+            if documentStartSupported {
+                let registration = registerDocumentStartPlan(
+                    persistentPlan,
+                    styleIDPrefix: persistentDocumentStartStyleIDPrefix,
+                    for: pageURL,
+                    in: view
+                )
+                persistentCosmeticScriptHandlers = registration.handlers
+                persistentDocumentStartStyleIDs = registration.styleIDs
+                registeredPersistentHandlerCount = registration.handlers.count
+            }
+            installedPersistentRules = desiredPersistentRules
+        }
+        let persistentRegisterMilliseconds = currentMilliseconds() - persistentRegisterStartedAt
+
+        let navigationRegisterStartedAt = currentMilliseconds()
+        var removedNavigationHandlerCount = 0
+        var registeredNavigationHandlerCount = 0
+        if navigationChanged {
+            removedNavigationHandlerCount = navigationCosmeticScriptHandlers.count
+            removeDocumentStartRegistrations(
+                handlers: &navigationCosmeticScriptHandlers,
+                styleIDs: &navigationDocumentStartStyleIDs
+            )
+            if documentStartSupported {
+                let registration = registerDocumentStartPlan(
+                    navigationPlan,
+                    styleIDPrefix: navigationDocumentStartStyleIDPrefix,
+                    for: pageURL,
+                    in: view
+                )
+                navigationCosmeticScriptHandlers = registration.handlers
+                navigationDocumentStartStyleIDs = registration.styleIDs
+                registeredNavigationHandlerCount = registration.handlers.count
+            }
+            installedNavigationRules = desiredNavigationRules
+        }
+        let navigationRegisterMilliseconds = currentMilliseconds() - navigationRegisterStartedAt
 
         androidPreparedCosmeticPageURL = pageURL.absoluteString
+        logger.info(
+            "Android blocker prepare url=\(pageURL.absoluteString) totalMs=\(formatMilliseconds(currentMilliseconds() - prepareStartedAt)) whitelisted=\(isWhitelisted) cosmeticQueryMs=\(formatMilliseconds(cosmeticQueryMilliseconds)) documentStartSupported=\(documentStartSupported) persistentChanged=\(persistentChanged) persistentRuleCount=\(desiredPersistentRules.count) persistentCSSCount=\(cssEntryCount(in: desiredPersistentRules)) persistentPlanMs=\(formatMilliseconds(persistentPlanMilliseconds)) persistentRegisterMs=\(formatMilliseconds(persistentRegisterMilliseconds)) removedPersistentHandlers=\(removedPersistentHandlerCount) registeredPersistentHandlers=\(registeredPersistentHandlerCount) navigationChanged=\(navigationChanged) navigationRuleCount=\(desiredNavigationRules.count) navigationCSSCount=\(cssEntryCount(in: desiredNavigationRules)) navigationPlanMs=\(formatMilliseconds(navigationPlanMilliseconds)) navigationRegisterMs=\(formatMilliseconds(navigationRegisterMilliseconds)) removedNavigationHandlers=\(removedNavigationHandlerCount) registeredNavigationHandlers=\(registeredNavigationHandlerCount)"
+        )
     }
 
-    func recoverIfNeeded(for url: String) {
+    func recoverIfNeeded(for url: String, in view: PlatformWebView) {
         guard androidPreparedCosmeticPageURL != url else {
             return
         }
         guard let pageURL = URL(string: url) else {
-            removeAllAndroidCosmeticScriptHandlers()
-            androidLifecycleCosmeticCSS = []
+            clearInsertedDocumentStartStyles(in: view)
+            persistentLifecycleCosmeticCSS = []
+            navigationLifecycleCosmeticCSS = []
             androidPreparedCosmeticPageURL = nil
             return
         }
 
+        let documentStartSupported = WebEngine.isAndroidDocumentStartScriptSupported()
+        let isWhitelisted = isWhitelisted(pageURL: pageURL)
+        let desiredPersistentRules = desiredPersistentRules(for: pageURL, isWhitelisted: isWhitelisted)
+        let desiredNavigationRules = desiredNavigationRules(for: pageURL, isWhitelisted: isWhitelisted)
+        let persistentChanged = desiredPersistentRules != installedPersistentRules
+        let navigationChanged = desiredNavigationRules != installedNavigationRules
+
         if androidPreparedCosmeticPageURL != nil {
             logger.info("Falling back to late Android cosmetic injection for \(pageURL.absoluteString)")
         }
-        removeAllAndroidCosmeticScriptHandlers()
-        let fallbackPlan = fallbackAndroidCosmeticPlan(for: pageURL)
-        androidLifecycleCosmeticCSS = fallbackPlan.lifecycleCSS
+
+        let persistentFuturePlan = WebEngine.androidCosmeticInjectionPlan(
+            rules: desiredPersistentRules,
+            pageURL: pageURL,
+            isDocumentStartSupported: documentStartSupported
+        ) { message in
+            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        }
+        let navigationFuturePlan = WebEngine.androidCosmeticInjectionPlan(
+            rules: desiredNavigationRules,
+            pageURL: pageURL,
+            isDocumentStartSupported: documentStartSupported
+        ) { message in
+            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        }
+        let persistentFallbackPlan = WebEngine.androidRedirectFallbackCosmeticPlan(
+            rules: desiredPersistentRules,
+            pageURL: pageURL
+        ) { message in
+            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        }
+        let navigationFallbackPlan = WebEngine.androidRedirectFallbackCosmeticPlan(
+            rules: desiredNavigationRules,
+            pageURL: pageURL
+        ) { message in
+            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
+        }
+
+        if persistentChanged {
+            let removedStyleIDs = persistentDocumentStartStyleIDs
+            removeDocumentStartRegistrations(
+                handlers: &persistentCosmeticScriptHandlers,
+                styleIDs: &persistentDocumentStartStyleIDs
+            )
+            clearInsertedStyles(styleIDs: removedStyleIDs, in: view)
+            if documentStartSupported {
+                let registration = registerDocumentStartPlan(
+                    persistentFuturePlan,
+                    styleIDPrefix: persistentDocumentStartStyleIDPrefix,
+                    for: pageURL,
+                    in: view
+                )
+                persistentCosmeticScriptHandlers = registration.handlers
+                persistentDocumentStartStyleIDs = registration.styleIDs
+            }
+            installedPersistentRules = desiredPersistentRules
+        }
+
+        if navigationChanged {
+            let removedStyleIDs = navigationDocumentStartStyleIDs
+            removeDocumentStartRegistrations(
+                handlers: &navigationCosmeticScriptHandlers,
+                styleIDs: &navigationDocumentStartStyleIDs
+            )
+            clearInsertedStyles(styleIDs: removedStyleIDs, in: view)
+            if documentStartSupported {
+                let registration = registerDocumentStartPlan(
+                    navigationFuturePlan,
+                    styleIDPrefix: navigationDocumentStartStyleIDPrefix,
+                    for: pageURL,
+                    in: view
+                )
+                navigationCosmeticScriptHandlers = registration.handlers
+                navigationDocumentStartStyleIDs = registration.styleIDs
+            }
+            installedNavigationRules = desiredNavigationRules
+        }
+
+        // Redirects are already loading the final document, so always recompute the
+        // late-injected CSS for that final URL even when the rule arrays are unchanged.
+        persistentLifecycleCosmeticCSS = persistentFallbackPlan.lifecycleCSS
+        navigationLifecycleCosmeticCSS = navigationFallbackPlan.lifecycleCSS
         androidPreparedCosmeticPageURL = pageURL.absoluteString
     }
 
     func injectIfNeeded(into view: PlatformWebView) {
-        guard let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
-            cssRules: androidLifecycleCosmeticCSS,
-            styleID: "__skipweb_content_blockers",
-            frameScope: .mainFrameOnly
-        ) else {
-            clearCSS(in: view)
-            return
-        }
-
-        view.evaluateJavascript(injectionScript) { _ in
-            logger.debug("Injected Android content blocker CSS")
-        }
+        injectLifecycleCSS(
+            persistentLifecycleCosmeticCSS,
+            styleID: persistentLifecycleStyleID,
+            in: view
+        )
+        injectLifecycleCSS(
+            navigationLifecycleCosmeticCSS,
+            styleID: navigationLifecycleStyleID,
+            in: view
+        )
     }
 
     func intercept(_ request: android.webkit.WebResourceRequest) -> android.webkit.WebResourceResponse? {
@@ -2316,47 +2516,88 @@ final class AndroidContentBlockerController {
         return nil
     }
 
-    private func removeAllAndroidCosmeticScriptHandlers() {
-        for handler in androidCosmeticScriptHandlers {
+    private func desiredPersistentRules(
+        for pageURL: URL,
+        isWhitelisted: Bool
+    ) -> [AndroidCosmeticRule] {
+        guard !isWhitelisted, let provider else {
+            return []
+        }
+        return provider.persistentCosmeticRules
+    }
+
+    private func desiredNavigationRules(
+        for pageURL: URL,
+        isWhitelisted: Bool
+    ) -> [AndroidCosmeticRule] {
+        guard !isWhitelisted, let provider else {
+            return []
+        }
+        return provider.navigationCosmeticRules(for: AndroidPageContext(url: pageURL))
+    }
+
+    private func isWhitelisted(pageURL: URL) -> Bool {
+        WebContentBlockerConfiguration.matchesWhitelistedURL(
+            pageURL,
+            in: config.contentBlockers?.normalizedWhitelistedDomains ?? []
+        )
+    }
+
+    private func removeDocumentStartRegistrations(
+        handlers: inout [ScriptHandler],
+        styleIDs: inout [String]
+    ) {
+        for handler in handlers {
             handler.remove()
         }
-        androidCosmeticScriptHandlers.removeAll()
+        handlers.removeAll()
+        styleIDs.removeAll()
     }
 
-    private func androidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
-        guard let provider else {
-            return AndroidCosmeticInjectionPlan()
-        }
-        return WebEngine.androidCosmeticInjectionPlan(
-            rules: provider.cosmeticRules(for: AndroidPageContext(url: pageURL)),
-            pageURL: pageURL,
-            isDocumentStartSupported: WebEngine.isAndroidDocumentStartScriptSupported()
-        ) { message in
-            logger.warning("\(message) for \(pageURL.absoluteString)")
-        }
-    }
+    private func registerDocumentStartPlan(
+        _ plan: AndroidCosmeticInjectionPlan,
+        styleIDPrefix: String,
+        for pageURL: URL,
+        in view: PlatformWebView
+    ) -> AndroidDocumentStartPlanRegistration {
+        var handlers: [ScriptHandler] = []
+        var styleIDs: [String] = []
 
-    private func fallbackAndroidCosmeticPlan(for pageURL: URL) -> AndroidCosmeticInjectionPlan {
-        guard let provider else {
-            return AndroidCosmeticInjectionPlan()
+        for (index, rule) in plan.documentStartRules.enumerated() {
+            let registerStartedAt = currentMilliseconds()
+            if let registration = registerAndroidDocumentStartCosmeticRule(
+                rule,
+                index: index,
+                styleIDPrefix: styleIDPrefix,
+                for: pageURL,
+                in: view
+            ) {
+                handlers.append(registration.handler)
+                styleIDs.append(registration.styleID)
+            }
+            let registerMilliseconds = currentMilliseconds() - registerStartedAt
+            logger.info(
+                "Android blocker register url=\(pageURL.absoluteString) prefix=\(styleIDPrefix) index=\(index) cssCount=\(rule.css.count) cssChars=\(cssCharacterCountInCSSRules(rule.css)) allowedOrigins=\(rule.allowedOriginRules.count) ms=\(formatMilliseconds(registerMilliseconds))"
+            )
         }
-        return WebEngine.androidRedirectFallbackCosmeticPlan(
-            rules: provider.cosmeticRules(for: AndroidPageContext(url: pageURL)),
-            pageURL: pageURL
-        ) { message in
-            logger.warning("\(message) for redirected final page \(pageURL.absoluteString)")
-        }
+
+        return AndroidDocumentStartPlanRegistration(
+            handlers: handlers,
+            styleIDs: styleIDs
+        )
     }
 
     private func registerAndroidDocumentStartCosmeticRule(
         _ rule: AndroidCosmeticRule,
         index: Int,
+        styleIDPrefix: String,
         for pageURL: URL,
         in view: PlatformWebView
-    ) -> ScriptHandler? {
+    ) -> AndroidDocumentStartRuleRegistration? {
+        let styleID = "\(styleIDPrefix)_\(index)"
         guard let script = WebEngine.androidContentBlockerStyleInjectionScript(
             cssRules: rule.css,
-            styleID: "__skipweb_content_blockers_\(index)",
+            styleID: styleID,
             frameScope: rule.frameScope,
             urlFilterPattern: rule.urlFilterPattern
         ) else {
@@ -2368,19 +2609,78 @@ final class AndroidContentBlockerController {
         }
 
         // SKIP INSERT: try {
-        // SKIP INSERT:     return androidx.webkit.WebViewCompat.addDocumentStartJavaScript(view, script_0, allowedOriginRules)
+        // SKIP INSERT:     return AndroidDocumentStartRuleRegistration(
+        // SKIP INSERT:         handler = androidx.webkit.WebViewCompat.addDocumentStartJavaScript(view, script_0, allowedOriginRules),
+        // SKIP INSERT:         styleID = styleID
+        // SKIP INSERT:     )
         // SKIP INSERT: } catch (t: Throwable) {
         // SKIP INSERT:     logger.warning("Skipping Android cosmetic rule registration for ${pageURL.absoluteString}: ${t.message ?: t}")
         // SKIP INSERT:     return null
         // SKIP INSERT: }
-        return WebViewCompat.addDocumentStartJavaScript(view, script, allowedOriginRules)
+        return AndroidDocumentStartRuleRegistration(
+            handler: WebViewCompat.addDocumentStartJavaScript(view, script, allowedOriginRules),
+            styleID: styleID
+        )
     }
 
-    private func clearCSS(in view: PlatformWebView) {
-        let removalScript = WebEngine.androidContentBlockerStyleRemovalScript(styleID: "__skipweb_content_blockers")
-        view.evaluateJavascript(removalScript) { _ in
-            logger.debug("Cleared Android content blocker CSS")
+    private func clearInsertedDocumentStartStyles(in view: PlatformWebView) {
+        clearInsertedStyles(styleIDs: persistentDocumentStartStyleIDs, in: view)
+        clearInsertedStyles(styleIDs: navigationDocumentStartStyleIDs, in: view)
+    }
+
+    private func clearInsertedStyles(styleIDs: [String], in view: PlatformWebView) {
+        for styleID in styleIDs {
+            let removalScript = WebEngine.androidContentBlockerStyleRemovalScript(styleID: styleID)
+            view.evaluateJavascript(removalScript) { _ in
+                logger.debug("Cleared Android content blocker CSS styleID=\(styleID)")
+            }
         }
+    }
+
+    private func injectLifecycleCSS(
+        _ cssRules: [String],
+        styleID: String,
+        in view: PlatformWebView
+    ) {
+        guard let injectionScript = WebEngine.androidContentBlockerStyleInjectionScript(
+            cssRules: cssRules,
+            styleID: styleID,
+            frameScope: .mainFrameOnly
+        ) else {
+            let removalScript = WebEngine.androidContentBlockerStyleRemovalScript(styleID: styleID)
+            view.evaluateJavascript(removalScript) { _ in
+                logger.debug("Cleared Android content blocker CSS styleID=\(styleID)")
+            }
+            return
+        }
+
+        view.evaluateJavascript(injectionScript) { _ in
+            logger.debug("Injected Android content blocker CSS styleID=\(styleID)")
+        }
+    }
+
+    private func currentMilliseconds() -> Double {
+        Date().timeIntervalSince1970 * 1000.0
+    }
+
+    private func formatMilliseconds(_ value: Double) -> String {
+        String((value * 10.0).rounded() / 10.0)
+    }
+
+    private func cssEntryCount(in rules: [AndroidCosmeticRule]) -> Int {
+        var count = 0
+        for rule in rules {
+            count += rule.css.count
+        }
+        return count
+    }
+
+    private func cssCharacterCountInCSSRules(_ cssRules: [String]) -> Int {
+        var count = 0
+        for cssRule in cssRules {
+            count += cssRule.count
+        }
+        return count
     }
 }
 
@@ -2418,7 +2718,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageCommitVisible(view: PlatformWebView, url: String) {
         logger.log("onPageCommitVisible: \(url)")
-        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         engine?.androidContentBlockerController.injectIfNeeded(into: view)
         embeddedNavigationClient?.onPageCommitVisible(view, url)
         legacyNavigationDelegate?.onPageCommitVisible(view, url)
@@ -2426,7 +2726,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageFinished(view: PlatformWebView, url: String) {
         logger.log("onPageFinished: \(url)")
-        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         engine?.androidContentBlockerController.injectIfNeeded(into: view)
         for userScript in config?.userScripts ?? [] {
             if userScript.webKitUserScript.injectionTime == .atDocumentEnd {
@@ -2446,7 +2746,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
         logger.log("onPageStarted: \(url)")
-        engine?.androidContentBlockerController.recoverIfNeeded(for: url)
+        engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         if !(config?.messageHandlers.isEmpty ?? true) {
             view.evaluateJavascript("""
             if (!window.webkit) window.webkit = {};
@@ -3030,12 +3330,28 @@ public extension SkipWebUIDelegate {
         #endif
     }
 
+    /// Prepare any configured content blockers and populate `contentBlockerSetupErrors`.
+    ///
+    /// On Apple platforms this compiles or loads persisted rule lists so later web view creation
+    /// can attach them without the initial compile cost. On other platforms this is a no-op.
+    @MainActor
+    @discardableResult
+    public func prepareContentBlockers() async -> [WebContentBlockerError] {
+        #if !SKIP
+        _ = await prepareIOSContentBlockerRuleLists()
+        return contentBlockerSetupErrors
+        #else
+        contentBlockerSetupErrors = []
+        return []
+        #endif
+    }
+
     #if !SKIP
     /// Create a `WebViewConfiguration` from the properties of this configuration and
     /// asynchronously install any configured iOS content blockers.
     @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration {
         let configuration = makeBaseWebViewConfiguration()
-        _ = await installContentBlockers(into: configuration.userContentController)
+        _ = await installPreparedContentBlockers(into: configuration.userContentController)
         return configuration
     }
 
@@ -3061,10 +3377,20 @@ public extension SkipWebUIDelegate {
 
     @MainActor
     @discardableResult
-    public func installContentBlockers(into userContentController: WKUserContentController) async -> [WebContentBlockerError] {
+    fileprivate func installPreparedContentBlockers(into userContentController: WKUserContentController) async -> [WebContentBlockerError] {
+        let prepared = await prepareIOSContentBlockerRuleLists()
+        for ruleList in prepared.ruleLists {
+            userContentController.add(ruleList)
+        }
+        WebContentBlockerStore.recordInstallation(count: prepared.ruleLists.count)
+        return prepared.errors
+    }
+
+    @MainActor
+    private func prepareIOSContentBlockerRuleLists() async -> PreparedContentBlockerRuleLists {
         contentBlockerSetupErrors = []
         guard let contentBlockers, !contentBlockers.iOSRuleListPaths.isEmpty else {
-            return []
+            return PreparedContentBlockerRuleLists(ruleLists: [], errors: [])
         }
 
         let prepared = await WebContentBlockerStore.prepareRuleLists(
@@ -3072,11 +3398,7 @@ public extension SkipWebUIDelegate {
             whitelistedDomains: contentBlockers.normalizedWhitelistedDomains
         )
         contentBlockerSetupErrors = prepared.errors
-        for ruleList in prepared.ruleLists {
-            userContentController.add(ruleList)
-        }
-        WebContentBlockerStore.recordInstallation(count: prepared.ruleLists.count)
-        return prepared.errors
+        return prepared
     }
 
     @MainActor private var webKitWebsiteDataStore: WKWebsiteDataStore {
@@ -3224,6 +3546,9 @@ fileprivate enum WebContentBlockerStore {
                 content,
                 whitelistedDomains: normalizedWhitelistedDomains
             )
+            if isEmptyRuleListContent(augmentedContent) {
+                continue
+            }
             let augmentedContentData = Data(augmentedContent.utf8)
             let identifier = ruleListIdentifier(for: sourcePath, contentData: augmentedContentData)
             nextIdentifiersBySourcePath[sourcePath] = identifier
@@ -3280,6 +3605,15 @@ fileprivate enum WebContentBlockerStore {
 
     private static func ruleListIdentifier(for sourcePath: String, contentData: Data) -> String {
         "skipweb.content-blocker.\(hexString(Insecure.SHA1.hash(data: Data(sourcePath.utf8)))).\(hexString(SHA256.hash(data: contentData)))"
+    }
+
+    private static func isEmptyRuleListContent(_ content: String) -> Bool {
+        guard let data = content.data(using: .utf8),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data),
+              let rules = jsonObject as? [Any] else {
+            return false
+        }
+        return rules.isEmpty
     }
 
     private static func makeStore(errors: inout [WebContentBlockerError]) -> WKContentRuleListStore? {

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -2896,6 +2896,15 @@ public extension SkipWebUIDelegate {
         return copy
     }
 
+    /// Clear any persisted compiled iOS content-blocker rule lists so the next install recompiles from source.
+    ///
+    /// The cache is shared across `WebEngineConfiguration` instances. On non-Apple platforms this is a no-op.
+    @MainActor public static func clearContentBlockerCache() throws {
+        #if !SKIP
+        try WebContentBlockerStore.clearPersistentState()
+        #endif
+    }
+
     #if !SKIP
     /// Create a `WebViewConfiguration` from the properties of this configuration and
     /// asynchronously install any configured iOS content blockers.

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -155,6 +155,7 @@ public enum WebProfileError: Error, Equatable {
 /// Think of it as the single place where apps describe:
 /// - iOS rule-list files to compile and install
 /// - domains that should bypass blocking entirely
+/// - popup source domains that should bypass popup blocking only
 /// - Android request and cosmetic blocking behavior
 public struct WebContentBlockerConfiguration {
     /// Paths to iOS WebKit content-blocker JSON files.
@@ -166,37 +167,33 @@ public struct WebContentBlockerConfiguration {
     ///
     /// Entries use WebKit-style host matching such as `example.com` and `*.example.com`.
     public var whitelistedDomains: [String]
+    /// Popup source-site allowlist entries that bypass popup blocking only.
+    ///
+    /// Bare domains such as `example.com` cover both the exact host and common
+    /// subdomains. Wildcard entries such as `*.example.com` cover subdomains only.
+    public var popupWhitelistedSourceDomains: [String]
     /// Primary Android content-blocking entry point.
     ///
     /// Use `.custom(...)` to supply request and cosmetic blocking behavior from one provider.
     public var androidMode: AndroidContentBlockingMode
-    /// Deprecated Android request-blocking compatibility shim.
-    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
-    public var androidRequestBlocker: (any AndroidRequestBlocker)?
-    /// Deprecated Android cosmetic-blocking compatibility shim.
-    @available(*, deprecated, message: "Use androidMode with AndroidContentBlockingMode.custom(...) instead.")
-    public var androidCosmeticBlocker: (any AndroidCosmeticBlocker)?
 
     /// Creates a content-blocker configuration.
     ///
     /// - Parameters:
     ///   - iOSRuleListPaths: iOS WebKit content-blocker JSON files to compile.
     ///   - whitelistedDomains: Host patterns that should bypass blocking.
+    ///   - popupWhitelistedSourceDomains: Popup source-site host patterns that should bypass popup blocking only.
     ///   - androidMode: Primary Android blocking configuration.
-    ///   - androidRequestBlocker: Deprecated Android request blocker bridge.
-    ///   - androidCosmeticBlocker: Deprecated Android cosmetic blocker bridge.
     public init(
         iOSRuleListPaths: [String] = [],
         whitelistedDomains: [String] = [],
-        androidMode: AndroidContentBlockingMode = .disabled,
-        androidRequestBlocker: (any AndroidRequestBlocker)? = nil,
-        androidCosmeticBlocker: (any AndroidCosmeticBlocker)? = nil
+        popupWhitelistedSourceDomains: [String] = [],
+        androidMode: AndroidContentBlockingMode = .disabled
     ) {
         self.iOSRuleListPaths = iOSRuleListPaths
         self.whitelistedDomains = whitelistedDomains
+        self.popupWhitelistedSourceDomains = popupWhitelistedSourceDomains
         self.androidMode = androidMode
-        self.androidRequestBlocker = androidRequestBlocker
-        self.androidCosmeticBlocker = androidCosmeticBlocker
     }
 }
 
@@ -294,12 +291,6 @@ public struct AndroidBlockableRequest: Equatable, Sendable {
     }
 }
 
-/// Deprecated compatibility protocol for Android request blocking.
-public protocol AndroidRequestBlocker {
-    /// Returns the request-blocking decision for an Android resource load.
-    func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
-}
-
 /// Page details passed to Android cosmetic blockers.
 public struct AndroidPageContext: Equatable, Sendable {
     /// The current page URL.
@@ -336,13 +327,20 @@ public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Send
 public struct AndroidCosmeticRule: Equatable, Sendable {
     /// Selector or selector-list entries to hide with `display: none !important`.
     public var hiddenSelectors: [String]
-    /// Optional regex-style URL filter that must match the page or frame URL.
+    /// Optional regex-style URL filter that must match the current frame URL before the rule applies.
+    ///
+    /// Think of it as a runtime frame guard: SkipWeb checks it inside the injected script
+    /// so a rule can stay registered while only applying to matching subframes or redirected pages.
     public var urlFilterPattern: String?
-    /// Allowed origin rules used for Android document-start script registration.
+    /// Allowed origins used when registering Android document-start scripts.
+    ///
+    /// This is a platform registration scope, not just an in-script filter.
+    /// `WebViewCompat.addDocumentStartJavaScript(...)` requires these origin rules up front,
+    /// so SkipWeb needs them to decide where the script is injected at all.
     public var allowedOriginRules: [String]
-    /// Host patterns that must match the page host.
+    /// Host patterns that must match the current frame host before the rule applies.
     public var ifDomainList: [String]
-    /// Host patterns that must not match the page host.
+    /// Host patterns that must not match the current frame host before the rule applies.
     public var unlessDomainList: [String]
     /// Frame scope for the injected CSS.
     public var frameScope: AndroidCosmeticFrameScope
@@ -383,12 +381,6 @@ public struct AndroidCosmeticRule: Equatable, Sendable {
     }
 }
 
-/// Deprecated compatibility protocol for Android cosmetic blocking.
-public protocol AndroidCosmeticBlocker {
-    /// Returns cosmetic rules for the given page.
-    func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule]
-}
-
 public protocol SkipWebNavigationDelegate {
     func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool
     func webEngineDidCommitNavigation(_ engine: WebEngine)
@@ -423,23 +415,6 @@ struct AndroidDocumentStartRuleBatchKey: Hashable {
     let allowedOriginRules: [String]
     let ifDomainList: [String]
     let unlessDomainList: [String]
-}
-
-fileprivate struct LegacyAndroidContentBlockingProvider: AndroidContentBlockingProvider {
-    let requestBlocker: (any AndroidRequestBlocker)?
-    let cosmeticBlocker: (any AndroidCosmeticBlocker)?
-
-    var persistentCosmeticRules: [AndroidCosmeticRule] {
-        []
-    }
-
-    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
-        requestBlocker?.decision(for: request) ?? .allow
-    }
-
-    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-        cosmeticBlocker?.cosmetics(for: page) ?? []
-    }
 }
 
 fileprivate struct WhitelistedAndroidContentBlockingProvider: AndroidContentBlockingProvider {
@@ -477,29 +452,12 @@ extension WebContentBlockerConfiguration {
         Self.normalizedWhitelistedDomains(from: whitelistedDomains)
     }
 
-    var hasLegacyAndroidHooks: Bool {
-        androidRequestBlocker != nil || androidCosmeticBlocker != nil
+    var normalizedPopupWhitelistedSourceDomains: [String] {
+        Self.normalizedWhitelistedDomains(from: popupWhitelistedSourceDomains)
     }
 
     var effectiveAndroidMode: AndroidContentBlockingMode {
-        let baseMode: AndroidContentBlockingMode
         switch androidMode {
-        case .disabled:
-            if hasLegacyAndroidHooks {
-                baseMode = .custom(
-                    LegacyAndroidContentBlockingProvider(
-                        requestBlocker: androidRequestBlocker,
-                        cosmeticBlocker: androidCosmeticBlocker
-                    )
-                )
-            } else {
-                baseMode = .disabled
-            }
-        case .custom:
-            baseMode = androidMode
-        }
-
-        switch baseMode {
         case .disabled:
             return .disabled
         case .custom(let provider):
@@ -564,27 +522,52 @@ extension WebContentBlockerConfiguration {
 
     #if !SKIP
     func augmentedIOSRuleListContent(_ content: String) -> String {
-        Self.augmentedIOSRuleListContent(content, whitelistedDomains: normalizedWhitelistedDomains)
+        Self.augmentedIOSRuleListContent(
+            content,
+            whitelistedDomains: normalizedWhitelistedDomains,
+            popupWhitelistedSourceDomains: normalizedPopupWhitelistedSourceDomains
+        )
     }
 
-    static func augmentedIOSRuleListContent(_ content: String, whitelistedDomains: [String]) -> String {
-        guard !whitelistedDomains.isEmpty,
+    static func augmentedIOSRuleListContent(
+        _ content: String,
+        whitelistedDomains: [String],
+        popupWhitelistedSourceDomains: [String] = []
+    ) -> String {
+        guard !whitelistedDomains.isEmpty || !popupWhitelistedSourceDomains.isEmpty,
               let data = content.data(using: .utf8),
               let jsonObject = try? JSONSerialization.jsonObject(with: data),
               var rules = jsonObject as? [[String: Any]] else {
             return content
         }
 
-        rules.append([
-            "comment": "user-injected domain exemptions (whitelisted domains)",
-            "trigger": [
-                "url-filter": ".*",
-                "if-domain": whitelistedDomains
-            ],
-            "action": [
-                "type": "ignore-previous-rules"
-            ]
-        ])
+        if !whitelistedDomains.isEmpty {
+            rules.append([
+                "comment": "user-injected domain exemptions (whitelisted domains)",
+                "trigger": [
+                    "url-filter": ".*",
+                    "if-domain": whitelistedDomains
+                ],
+                "action": [
+                    "type": "ignore-previous-rules"
+                ]
+            ])
+        }
+
+        let popupTopURLs = popupWhitelistTopURLs(from: popupWhitelistedSourceDomains)
+        if !popupTopURLs.isEmpty {
+            rules.append([
+                "comment": "user-injected popup exemptions (allowed source domains)",
+                "trigger": [
+                    "url-filter": ".*",
+                    "resource-type": ["popup"],
+                    "if-top-url": popupTopURLs
+                ],
+                "action": [
+                    "type": "ignore-previous-rules"
+                ]
+            ])
+        }
 
         guard JSONSerialization.isValidJSONObject(rules),
               let augmentedData = try? JSONSerialization.data(withJSONObject: rules, options: [.sortedKeys]),
@@ -593,6 +576,25 @@ extension WebContentBlockerConfiguration {
         }
 
         return augmentedContent
+    }
+
+    static func popupWhitelistTopURLs(from domains: [String]) -> [String] {
+        Array(
+            Set(
+                domains.flatMap { domain in
+                    if domain.hasPrefix("*.") {
+                        return ["http://\(domain)/*", "https://\(domain)/*"]
+                    } else {
+                        return [
+                            "http://\(domain)/*",
+                            "http://*.\(domain)/*",
+                            "https://\(domain)/*",
+                            "https://*.\(domain)/*",
+                        ]
+                    }
+                }
+            )
+        ).sorted()
     }
     #endif
 }
@@ -2931,26 +2933,25 @@ final class AndroidContentBlockerController {
             return nil
         }
         let headers = WebEngine.androidRequestHeaders(from: request)
-        let decision = provider.requestDecision(
-            for: AndroidBlockableRequest(
-                url: requestURL,
-                mainDocumentURL: WebEngine.androidMainDocumentURL(
-                    for: request,
-                    requestURL: requestURL,
-                    headers: headers
-                ),
-                method: request.method,
-                headers: headers,
-                isForMainFrame: request.isForMainFrame,
-                hasGesture: request.hasGesture(),
-                isRedirect: WebEngine.androidRequestIsRedirect(request),
-                resourceTypeHint: WebEngine.androidResourceTypeHint(
-                    for: request,
-                    requestURL: requestURL,
-                    headers: headers
-                )
+        let blockableRequest = AndroidBlockableRequest(
+            url: requestURL,
+            mainDocumentURL: WebEngine.androidMainDocumentURL(
+                for: request,
+                requestURL: requestURL,
+                headers: headers
+            ),
+            method: request.method,
+            headers: headers,
+            isForMainFrame: request.isForMainFrame,
+            hasGesture: request.hasGesture(),
+            isRedirect: WebEngine.androidRequestIsRedirect(request),
+            resourceTypeHint: WebEngine.androidResourceTypeHint(
+                for: request,
+                requestURL: requestURL,
+                headers: headers
             )
         )
+        let decision = provider.requestDecision(for: blockableRequest)
         if case .block = decision {
             return WebEngine.blockedAndroidResponse()
         }
@@ -3190,6 +3191,39 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
         engine?.configuration
     }
 
+    private func logViewportProbe(stage: String, view: PlatformWebView, url: String) {
+        logger.log(
+            "viewport probe native stage=\(stage) url=\(url) size=\(view.width)x\(view.height) measured=\(view.measuredWidth)x\(view.measuredHeight) contentHeight=\(view.contentHeight) scale=\(view.scale) scroll=\(view.scrollX),\(view.scrollY) visibility=\(view.visibility) alpha=\(view.alpha)"
+        )
+
+        let script = """
+        (function() {
+            try {
+                var doc = document.documentElement;
+                var body = document.body;
+                var vv = window.visualViewport;
+                return JSON.stringify({
+                    href: location.href,
+                    readyState: document.readyState,
+                    innerWidth: window.innerWidth,
+                    innerHeight: window.innerHeight,
+                    clientWidth: doc ? doc.clientWidth : null,
+                    clientHeight: doc ? doc.clientHeight : null,
+                    visualViewportWidth: vv ? vv.width : null,
+                    visualViewportHeight: vv ? vv.height : null,
+                    bodyChildCount: body ? body.children.length : null,
+                    bodyTextLength: body && body.innerText ? body.innerText.length : null
+                });
+            } catch (error) {
+                return JSON.stringify({ error: String(error) });
+            }
+        })();
+        """
+        view.evaluateJavascript(script) { result in
+            logger.log("viewport probe js stage=\(stage) url=\(url) result=\(String(describing: result))")
+        }
+    }
+
     override func doUpdateVisitedHistory(view: PlatformWebView, url: String, isReload: Bool) {
         logger.log("application")
         embeddedNavigationClient?.doUpdateVisitedHistory(view, url, isReload)
@@ -3210,6 +3244,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageCommitVisible(view: PlatformWebView, url: String) {
         logger.log("onPageCommitVisible: \(url)")
+        logViewportProbe(stage: "commit-visible", view: view, url: url)
         engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         engine?.androidContentBlockerController.injectIfNeeded(into: view)
         embeddedNavigationClient?.onPageCommitVisible(view, url)
@@ -3218,6 +3253,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageFinished(view: PlatformWebView, url: String) {
         logger.log("onPageFinished: \(url)")
+        logViewportProbe(stage: "page-finished", view: view, url: url)
         engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         engine?.androidContentBlockerController.injectIfNeeded(into: view)
         for userScript in config?.userScripts ?? [] {
@@ -3238,6 +3274,7 @@ final class AndroidEngineWebViewClient : android.webkit.WebViewClient {
 
     override func onPageStarted(view: PlatformWebView, url: String, favicon: android.graphics.Bitmap?) {
         logger.log("onPageStarted: \(url)")
+        logViewportProbe(stage: "page-started", view: view, url: url)
         engine?.androidContentBlockerController.recoverIfNeeded(for: url, in: view)
         if !(config?.messageHandlers.isEmpty ?? true) {
             view.evaluateJavascript("""
@@ -3751,6 +3788,13 @@ public extension SkipWebUIDelegate {
     #if SKIP
     /// The Android context to use for creating a web context
     public var context: android.content.Context? = nil
+    /// Optional Android-only callback for popup child-window creation.
+    ///
+    /// Think of it as the Android popup hook that runs before `SkipWebUIDelegate`:
+    /// return a child `WebEngine` to allow popup creation, or `nil` to deny it.
+    public var androidCreateWindowHandler: ((WebView, WebWindowRequest, AndroidCreateWindowParams) -> WebEngine?)?
+    /// Optional Android-only callback for popup child-window closure events.
+    public var androidCloseWindowHandler: ((WebView, WebEngine) -> Void)?
     #endif
 
     public init(javaScriptEnabled: Bool = true,
@@ -3811,6 +3855,8 @@ public extension SkipWebUIDelegate {
         )
         #if SKIP
         copy.context = context
+        copy.androidCreateWindowHandler = androidCreateWindowHandler
+        copy.androidCloseWindowHandler = androidCloseWindowHandler
         #endif
         return copy
     }
@@ -3818,7 +3864,7 @@ public extension SkipWebUIDelegate {
     /// Clears the persisted iOS content-blocker cache so the next setup recompiles from source.
     ///
     /// The cache is shared across `WebEngineConfiguration` instances. On non-Apple platforms this is a no-op.
-    @MainActor public static func clearContentBlockerCache() throws {
+    @MainActor public static func iOSClearContentBlockerCache() throws {
         #if !SKIP
         try WebContentBlockerStore.clearPersistentState()
         #endif
@@ -3830,7 +3876,7 @@ public extension SkipWebUIDelegate {
     /// can attach them without the initial compile cost. On other platforms this is a no-op.
     @MainActor
     @discardableResult
-    public func prepareContentBlockers() async -> [WebContentBlockerError] {
+    public func iOSPrepareContentBlockers() async -> [WebContentBlockerError] {
         #if !SKIP
         _ = await prepareIOSContentBlockerRuleLists()
         return contentBlockerSetupErrors
@@ -3889,7 +3935,8 @@ public extension SkipWebUIDelegate {
 
         let prepared = await WebContentBlockerStore.prepareRuleLists(
             from: contentBlockers.iOSRuleListPaths,
-            whitelistedDomains: contentBlockers.normalizedWhitelistedDomains
+            whitelistedDomains: contentBlockers.normalizedWhitelistedDomains,
+            popupWhitelistedSourceDomains: contentBlockers.normalizedPopupWhitelistedSourceDomains
         )
         contentBlockerSetupErrors = prepared.errors
         return prepared
@@ -3979,6 +4026,18 @@ struct WebContentBlockerDiagnostics: Equatable {
             whitelistedDomains: WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: whitelistedDomains)
         )
     }
+
+    static func augmentedRuleListContent(
+        _ content: String,
+        whitelistedDomains: [String],
+        popupWhitelistedSourceDomains: [String]
+    ) -> String {
+        WebContentBlockerConfiguration.augmentedIOSRuleListContent(
+            content,
+            whitelistedDomains: WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: whitelistedDomains),
+            popupWhitelistedSourceDomains: WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: popupWhitelistedSourceDomains)
+        )
+    }
 }
 
 @MainActor
@@ -4000,12 +4059,17 @@ fileprivate enum WebContentBlockerStore {
     private static let storeDirectoryName = "RuleListStore"
     private static let metadataVersion = 1
 
-    static func prepareRuleLists(from sourcePaths: [String], whitelistedDomains: [String]) async -> PreparedContentBlockerRuleLists {
+    static func prepareRuleLists(
+        from sourcePaths: [String],
+        whitelistedDomains: [String],
+        popupWhitelistedSourceDomains: [String] = []
+    ) async -> PreparedContentBlockerRuleLists {
         var ruleLists: [WKContentRuleList] = []
         var errors: [WebContentBlockerError] = []
 
         let normalizedSourcePaths = normalizedPaths(from: sourcePaths)
         let normalizedWhitelistedDomains = WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: whitelistedDomains)
+        let normalizedPopupWhitelistedSourceDomains = WebContentBlockerConfiguration.normalizedWhitelistedDomains(from: popupWhitelistedSourceDomains)
         guard !normalizedSourcePaths.isEmpty else {
             diagnostics.errors = []
             return PreparedContentBlockerRuleLists(ruleLists: [], errors: [])
@@ -4038,7 +4102,8 @@ fileprivate enum WebContentBlockerStore {
 
             let augmentedContent = WebContentBlockerConfiguration.augmentedIOSRuleListContent(
                 content,
-                whitelistedDomains: normalizedWhitelistedDomains
+                whitelistedDomains: normalizedWhitelistedDomains,
+                popupWhitelistedSourceDomains: normalizedPopupWhitelistedSourceDomains
             )
             if isEmptyRuleListContent(augmentedContent) {
                 continue

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -637,8 +637,10 @@ extension WebView : ViewRepresentable {
         context.coordinator.navigator.webEngine = webEngine
 
         let webView = webEngine.webView
-        if let error = webEngine.contentBlockerSetupErrors.first {
-            context.coordinator.state.error = error
+        Task { @MainActor in
+            if let error = await webEngine.awaitContentBlockerSetup().first {
+                context.coordinator.state.error = error
+            }
         }
 
         webView.allowsLinkPreview = true

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -382,7 +382,7 @@ final class SkipWebChromeClient : android.webkit.WebChromeClient {
 
         childEngine.webView.setBackgroundColor(0x000000)
         childEngine.webView.addJavascriptInterface(MessageHandlerRouter(webEngine: childEngine), "skipWebAndroidMessageHandler")
-        childEngine.engineDelegate = WebEngineDelegate(childEngine.configuration, WebViewClient(
+        childEngine.setAndroidEmbeddedNavigationClient(WebViewClient(
             state: self.webView.state,
             onNavigationCommitted: self.webView.onNavigationCommitted,
             onNavigationFinished: self.webView.onNavigationFinished,
@@ -472,7 +472,7 @@ extension WebView : ViewRepresentable {
         }
         webEngine.webView.setBackgroundColor(0x000000) // prevents screen flashing: https://issuetracker.google.com/issues/314821744
         webEngine.webView.addJavascriptInterface(MessageHandlerRouter(webEngine: webEngine), "skipWebAndroidMessageHandler")
-        webEngine.engineDelegate = WebEngineDelegate(webEngine.configuration, WebViewClient(
+        webEngine.setAndroidEmbeddedNavigationClient(WebViewClient(
             state: state,
             onNavigationCommitted: onNavigationCommitted,
             onNavigationFinished: onNavigationFinished,

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -591,7 +591,7 @@ extension WebView : ViewRepresentable {
                 config.context = ctx
                 // Re-use the navigator-owned engine so Android WebView survives
                 // screen navigation with the same navigator instance.
-                let webEngine = navigator.webEngine ?? WebEngine(config)
+                let webEngine = navigator.webEngine ?? WebEngine(configuration: config)
 
                 return setupWebView(webEngine, coordinator: coordinator).webView
             }, modifier: ctx.modifier, update: { webView in
@@ -637,6 +637,9 @@ extension WebView : ViewRepresentable {
         context.coordinator.navigator.webEngine = webEngine
 
         let webView = webEngine.webView
+        if let error = webEngine.contentBlockerSetupErrors.first {
+            context.coordinator.state.error = error
+        }
 
         webView.allowsLinkPreview = true
         webView.navigationDelegate = context.coordinator

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -12,6 +12,7 @@ public typealias PlatformWebView = android.webkit.WebView
 //import android.webkit.WebView // not imported because it conflicts with SkipWeb.WebView
 
 import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat.startActivity
@@ -20,6 +21,7 @@ import android.webkit.WebViewClient
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
+import android.view.ViewGroup
 
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewAssetLoader
@@ -218,7 +220,7 @@ public class WebViewNavigator: @unchecked Sendable {
         logger.info("goForward webView: \(self.webEngine?.description ?? "NONE")")
         webEngine?.goForward()
     }
-    
+
     @MainActor public func evaluateJavaScript(_ js: String) async throws -> String? {
         logger.info("evaluateJavaScript: \(js)")
         return try await webEngine?.evaluate(js: js)
@@ -394,7 +396,9 @@ final class SkipWebChromeClient : android.webkit.WebChromeClient {
     }
 
     override func onCreateWindow(view: PlatformWebView, isDialog: Bool, isUserGesture: Bool, resultMsg: android.os.Message) -> Bool {
-        guard let uiDelegate = webEngine.configuration.uiDelegate else {
+        let createWindowHandler = webEngine.configuration.androidCreateWindowHandler
+        let uiDelegate = webEngine.configuration.uiDelegate
+        guard createWindowHandler != nil || uiDelegate != nil else {
             return false
         }
 
@@ -412,11 +416,17 @@ final class SkipWebChromeClient : android.webkit.WebChromeClient {
             resultMessage: resultMsg
         )
 
-        guard let childEngine = uiDelegate.webView(
-            webView,
-            createWebViewWith: request,
-            platformContext: params
-        ) else {
+        let childEngine: WebEngine?
+        if let createWindowHandler {
+            childEngine = createWindowHandler(webView, request, params)
+        } else {
+            childEngine = uiDelegate?.webView(
+                webView,
+                createWebViewWith: request,
+                platformContext: params
+            )
+        }
+        guard let childEngine else {
             return false
         }
 
@@ -442,7 +452,11 @@ final class SkipWebChromeClient : android.webkit.WebChromeClient {
         guard let childEngine = childEnginesByWebViewHash.removeValue(forKey: window.hashCode()) else {
             return
         }
-        webEngine.configuration.uiDelegate?.webViewDidClose(webView, child: childEngine)
+        if let closeWindowHandler = webEngine.configuration.androidCloseWindowHandler {
+            closeWindowHandler(self.webView, childEngine)
+        } else {
+            webEngine.configuration.uiDelegate?.webViewDidClose(self.webView, child: childEngine)
+        }
     }
 }
 
@@ -462,7 +476,9 @@ extension WebView : ViewRepresentable {
         let settings = webEngine.webView.settings
         settings.setJavaScriptEnabled(config.javaScriptEnabled)
         settings.setJavaScriptCanOpenWindowsAutomatically(config.javaScriptCanOpenWindowsAutomatically)
-        settings.setSupportMultipleWindows(config.uiDelegate != nil)
+        settings.setSupportMultipleWindows(
+            config.uiDelegate != nil || config.androidCreateWindowHandler != nil
+        )
         settings.setSafeBrowsingEnabled(false)
         settings.setAllowContentAccess(true)
         settings.setAllowFileAccess(true)
@@ -479,7 +495,7 @@ extension WebView : ViewRepresentable {
             onNavigationFailed: onNavigationFailed,
             shouldOverrideUrlLoadingHandler: shouldOverrideUrlLoading
         ))
-        if config.uiDelegate != nil {
+        if config.uiDelegate != nil || config.androidCreateWindowHandler != nil {
             webEngine.webView.webChromeClient = SkipWebChromeClient(webView: self, webEngine: webEngine)
         } else {
             webEngine.webView.webChromeClient = android.webkit.WebChromeClient()
@@ -592,9 +608,21 @@ extension WebView : ViewRepresentable {
                 // Re-use the navigator-owned engine so Android WebView survives
                 // screen navigation with the same navigator instance.
                 let webEngine = navigator.webEngine ?? WebEngine(configuration: config)
-
-                return setupWebView(webEngine, coordinator: coordinator).webView
-            }, modifier: ctx.modifier, update: { webView in
+                let view = setupWebView(webEngine, coordinator: coordinator).webView
+                // AndroidView does not reliably push the parent's fill constraints into the
+                // embedded WebView on the first layout pass, so we request fill sizing from both
+                // Compose and the native view to avoid a zero-height viewport.
+                view.layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                view.minimumHeight = 1
+                return view
+            }, modifier: ctx.modifier.fillMaxSize(), update: { webView in
+                webView.layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
                 coordinator.update(from: self)
                 coordinator.configureAndroidScrollTracking(webView: webView)
                 self.update(webView: webView, coordinator: coordinator)

--- a/Tests/SkipWebTests/SkipWebTests.swift
+++ b/Tests/SkipWebTests/SkipWebTests.swift
@@ -296,7 +296,7 @@ final class SkipWebTests: XCTestCase {
         }
         #if !SKIP
         let config = WebEngineConfiguration()
-        let platformWebView = PlatformWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 240), configuration: config.webViewConfiguration)
+        let platformWebView = PlatformWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 240), configuration: await config.makeWebViewConfiguration())
         let engine = WebEngine(configuration: config, webView: platformWebView)
         engine.refreshMessageHandlers()
         engine.updateUserScripts()
@@ -329,7 +329,7 @@ final class SkipWebTests: XCTestCase {
         }
         #if !SKIP
         let config = WebEngineConfiguration()
-        let platformWebView = PlatformWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 240), configuration: config.webViewConfiguration)
+        let platformWebView = PlatformWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 240), configuration: await config.makeWebViewConfiguration())
         let engine = WebEngine(configuration: config, webView: platformWebView)
         engine.refreshMessageHandlers()
         engine.updateUserScripts()
@@ -496,7 +496,7 @@ final class SkipWebTests: XCTestCase {
         config.context = ctx
         let platformWebView = PlatformWebView(ctx)
         #else
-        let platformWebView = PlatformWebView(frame: CGRectZero, configuration: config.webViewConfiguration)
+        let platformWebView = PlatformWebView(frame: CGRectZero, configuration: await config.makeWebViewConfiguration())
         #endif
 
         let engine = WebEngine(configuration: config, webView: platformWebView)
@@ -691,7 +691,7 @@ final class SkipWebTests: XCTestCase {
         if isRobolectric {
             throw XCTSkip("WebEngine-backed data removal tests require instrumented Android context")
         }
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         let types: Set<WebSiteDataType> = [.cookies]
         do {
             try await engine.removeData(ofTypes: types, modifiedSince: Date())
@@ -709,7 +709,7 @@ final class SkipWebTests: XCTestCase {
         if isRobolectric {
             throw XCTSkip("WebEngine-backed data removal tests require instrumented Android context")
         }
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         try await engine.removeData(ofTypes: [], modifiedSince: .distantPast)
     }
 
@@ -719,7 +719,7 @@ final class SkipWebTests: XCTestCase {
             throw XCTSkip("cookie store is not reliable in Robolectric")
         }
 
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         await engine.clearCookies()
 
         let requestURL = try XCTUnwrap(URL(string: "https://cookies.example.com/path"))
@@ -739,7 +739,7 @@ final class SkipWebTests: XCTestCase {
             throw XCTSkip("cookie store is not reliable in Robolectric")
         }
 
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         await engine.clearCookies()
 
         let cookieName = "secure_cookie_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
@@ -763,7 +763,7 @@ final class SkipWebTests: XCTestCase {
             throw XCTSkip("cookie store is not reliable in Robolectric")
         }
 
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         await engine.clearCookies()
 
         let requestURL = try XCTUnwrap(URL(string: "https://cleanup.example.com/"))
@@ -785,7 +785,7 @@ final class SkipWebTests: XCTestCase {
             throw XCTSkip("cookie store is not reliable in Robolectric")
         }
 
-        let engine = makeCookieTestEngine()
+        let engine = await makeCookieTestEngine()
         await engine.clearCookies()
 
         let responseURL = try XCTUnwrap(URL(string: "https://headers.example.com/media/master.m3u8"))

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -117,7 +117,7 @@ final class WebContentBlockerTests: XCTestCase {
     func testPopupChildMirroredConfigurationPreservesAndroidBlockingMode() {
         let provider = StaticContentBlockingProvider(
             decision: AndroidRequestBlockDecision.block,
-            navigationRules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
+            navigationRules: [AndroidCosmeticRule(hiddenSelectors: [".ad"])]
         )
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
@@ -149,7 +149,7 @@ final class WebContentBlockerTests: XCTestCase {
         let contentBlockers = WebContentBlockerConfiguration(
             androidRequestBlocker: AllowAllRequestBlocker(),
             androidCosmeticBlocker: StaticCosmeticBlocker(
-                rules: [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
+                rules: [AndroidCosmeticRule(hiddenSelectors: [".legacy"])]
             )
         )
 
@@ -167,7 +167,7 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(decision, AndroidRequestBlockDecision.allow)
         XCTAssertEqual(
             provider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
-            [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
+            [AndroidCosmeticRule(hiddenSelectors: [".legacy"])]
         )
     }
 
@@ -229,7 +229,7 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies whitelist wrapping no longer suppresses cosmetics at the provider layer.
     func testAndroidWhitelistedDomainsDoNotSuppressProviderCosmeticRules() {
         let provider = StaticContentBlockingProvider(
-            navigationRules: [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
+            navigationRules: [AndroidCosmeticRule(hiddenSelectors: [".ad"])]
         )
         let contentBlockers = WebContentBlockerConfiguration(
             whitelistedDomains: ["example.com"],
@@ -242,13 +242,13 @@ final class WebContentBlockerTests: XCTestCase {
 
         XCTAssertEqual(
             effectiveProvider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com/page")!)),
-            [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
+            [AndroidCosmeticRule(hiddenSelectors: [".ad"])]
         )
     }
 
     // Verifies Android non-whitelisted domains still use the underlying provider unchanged.
     func testAndroidNonWhitelistedDomainsStillUseUnderlyingProvider() {
-        let rule = AndroidCosmeticRule(css: [".ad { display: none !important; }"])
+        let rule = AndroidCosmeticRule(hiddenSelectors: [".ad"])
         let provider = StaticContentBlockingProvider(
             decision: AndroidRequestBlockDecision.block,
             navigationRules: [rule]
@@ -295,10 +295,12 @@ final class WebContentBlockerTests: XCTestCase {
 
     // Verifies Android cosmetic rules default to wildcard origins, main-frame scope, and document-start timing.
     func testAndroidCosmeticRuleDefaults() {
-        let rule = AndroidCosmeticRule(css: [".ad { display: none !important; }"])
+        let rule = AndroidCosmeticRule(hiddenSelectors: [".ad"])
 
         XCTAssertNil(rule.urlFilterPattern)
         XCTAssertEqual(rule.allowedOriginRules, ["*"])
+        XCTAssertTrue(rule.ifDomainList.isEmpty)
+        XCTAssertTrue(rule.unlessDomainList.isEmpty)
         XCTAssertEqual(rule.frameScope, .mainFrameOnly)
         XCTAssertEqual(rule.preferredTiming, .documentStart)
     }
@@ -312,16 +314,20 @@ final class WebContentBlockerTests: XCTestCase {
             ],
             urlFilterPattern: ".*\\/ad-frame\\.html",
             allowedOriginRules: ["https://*.doubleclick.net"],
+            ifDomainList: ["ads.example.com"],
+            unlessDomainList: ["private.ads.example.com"],
             frameScope: .subframesOnly,
             preferredTiming: .documentStart
         )
 
-        XCTAssertEqual(rule.css, [
-            ".ad-banner { display: none !important; }",
-            "#sponsored { display: none !important; }"
+        XCTAssertEqual(rule.hiddenSelectors, [
+            ".ad-banner",
+            "#sponsored"
         ])
         XCTAssertEqual(rule.urlFilterPattern, ".*\\/ad-frame\\.html")
         XCTAssertEqual(rule.allowedOriginRules, ["https://*.doubleclick.net"])
+        XCTAssertEqual(rule.ifDomainList, ["ads.example.com"])
+        XCTAssertEqual(rule.unlessDomainList, ["private.ads.example.com"])
         XCTAssertEqual(rule.frameScope, .subframesOnly)
         XCTAssertEqual(rule.preferredTiming, .documentStart)
     }
@@ -395,13 +401,13 @@ final class WebContentBlockerTests: XCTestCase {
     func testAndroidCosmeticPlanPreservesDocumentStartRuleOrder() {
         let rules = [
             AndroidCosmeticRule(
-                css: [".primary { display: none !important; }"],
+                hiddenSelectors: [".primary"],
                 allowedOriginRules: ["https://*.doubleclick.net"],
                 frameScope: .subframesOnly,
                 preferredTiming: .documentStart
             ),
             AndroidCosmeticRule(
-                css: [".secondary { opacity: 0 !important; }"],
+                hiddenSelectors: [".secondary"],
                 allowedOriginRules: ["*"],
                 frameScope: .allFrames,
                 preferredTiming: .documentStart
@@ -418,16 +424,42 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertTrue(plan.lifecycleCSS.isEmpty)
     }
 
+    // Verifies document-start batching keeps unlike domain-list guards in separate rules.
+    func testAndroidCosmeticPlanKeepsDocumentStartRulesSeparateWhenDomainListsDiffer() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    hiddenSelectors: [".news"],
+                    ifDomainList: ["news.example.com"],
+                    frameScope: .allFrames,
+                    preferredTiming: .documentStart
+                ),
+                AndroidCosmeticRule(
+                    hiddenSelectors: [".sports"],
+                    ifDomainList: ["sports.example.com"],
+                    frameScope: .allFrames,
+                    preferredTiming: .documentStart
+                )
+            ],
+            pageURL: URL(string: "https://example.com")!,
+            isDocumentStartSupported: true
+        )
+
+        XCTAssertEqual(plan.documentStartRules.count, 2)
+        XCTAssertEqual(plan.documentStartRules[0].ifDomainList, ["news.example.com"])
+        XCTAssertEqual(plan.documentStartRules[1].ifDomainList, ["sports.example.com"])
+    }
+
     // Verifies unsupported document-start injection falls back only for main-frame rules.
     func testAndroidCosmeticPlanFallsBackOnlyForMainFrameRulesWhenUnsupported() {
         let plan = WebEngine.androidCosmeticInjectionPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".main { display: none !important; }"],
+                    hiddenSelectors: [".main"],
                     preferredTiming: .documentStart
                 ),
                 AndroidCosmeticRule(
-                    css: [".subframe { display: none !important; }"],
+                    hiddenSelectors: [".subframe"],
                     frameScope: .subframesOnly,
                     preferredTiming: .documentStart
                 )
@@ -445,11 +477,11 @@ final class WebContentBlockerTests: XCTestCase {
         let plan = WebEngine.androidCosmeticInjectionPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".late { display: none !important; }"],
+                    hiddenSelectors: [".late"],
                     preferredTiming: .pageLifecycle
                 ),
                 AndroidCosmeticRule(
-                    css: [".ignored { display: none !important; }"],
+                    hiddenSelectors: [".ignored"],
                     frameScope: .allFrames,
                     preferredTiming: .pageLifecycle
                 )
@@ -467,13 +499,40 @@ final class WebContentBlockerTests: XCTestCase {
         let plan = WebEngine.androidCosmeticInjectionPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".match { display: none !important; }"],
+                    hiddenSelectors: [".match"],
                     allowedOriginRules: ["https://*.example.com"],
                     preferredTiming: .pageLifecycle
                 ),
                 AndroidCosmeticRule(
-                    css: [".skip { display: none !important; }"],
+                    hiddenSelectors: [".skip"],
                     allowedOriginRules: ["https://ads.example.net"],
+                    preferredTiming: .pageLifecycle
+                )
+            ],
+            pageURL: URL(string: "https://news.example.com")!,
+            isDocumentStartSupported: true
+        )
+
+        XCTAssertEqual(plan.lifecycleCSS, [".match { display: none !important; }"])
+    }
+
+    // Verifies page-lifecycle fallback honors current-document domain guards before injecting into the main frame.
+    func testAndroidCosmeticPlanFiltersLifecycleRulesByDomainLists() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    hiddenSelectors: [".match"],
+                    ifDomainList: ["news.example.com"],
+                    preferredTiming: .pageLifecycle
+                ),
+                AndroidCosmeticRule(
+                    hiddenSelectors: [".skip"],
+                    ifDomainList: ["sports.example.com"],
+                    preferredTiming: .pageLifecycle
+                ),
+                AndroidCosmeticRule(
+                    hiddenSelectors: [".excluded"],
+                    unlessDomainList: ["news.example.com"],
                     preferredTiming: .pageLifecycle
                 )
             ],
@@ -489,12 +548,12 @@ final class WebContentBlockerTests: XCTestCase {
         let plan = WebEngine.androidCosmeticInjectionPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".match { display: none !important; }"],
+                    hiddenSelectors: [".match"],
                     allowedOriginRules: ["https://example.com"],
                     preferredTiming: .documentStart
                 ),
                 AndroidCosmeticRule(
-                    css: [".skip { display: none !important; }"],
+                    hiddenSelectors: [".skip"],
                     allowedOriginRules: ["https://other.example.com"],
                     preferredTiming: .documentStart
                 )
@@ -511,12 +570,12 @@ final class WebContentBlockerTests: XCTestCase {
         let plan = WebEngine.androidCosmeticInjectionPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".match { display: none !important; }"],
+                    hiddenSelectors: [".match"],
                     urlFilterPattern: ".*\\/index\\.html",
                     preferredTiming: .documentStart
                 ),
                 AndroidCosmeticRule(
-                    css: [".skip { display: none !important; }"],
+                    hiddenSelectors: [".skip"],
                     urlFilterPattern: ".*\\/subframe\\.html",
                     preferredTiming: .documentStart
                 )
@@ -533,11 +592,11 @@ final class WebContentBlockerTests: XCTestCase {
         let plan = WebEngine.androidRedirectFallbackCosmeticPlan(
             rules: [
                 AndroidCosmeticRule(
-                    css: [".main { display: none !important; }"],
+                    hiddenSelectors: [".main"],
                     preferredTiming: .documentStart
                 ),
                 AndroidCosmeticRule(
-                    css: [".subframe { display: none !important; }"],
+                    hiddenSelectors: [".subframe"],
                     frameScope: .subframesOnly,
                     preferredTiming: .documentStart
                 )
@@ -591,6 +650,103 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertTrue(script.contains("new RegExp"))
         XCTAssertTrue(script.contains("window.location.href"))
         XCTAssertTrue(script.contains("subframe\\\\.html"))
+    }
+
+    // Verifies domain-scoped scripts bail out unless the current frame host matches the provided domain lists.
+    func testAndroidContentBlockerStyleInjectionScriptAddsDomainGuards() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerStyleInjectionScript(
+                cssRules: [".subframe { display: none !important; }"],
+                styleID: "domain-style",
+                frameScope: AndroidCosmeticFrameScope.allFrames,
+                ifDomainList: ["ads.example.com"],
+                unlessDomainList: ["private.ads.example.com"]
+            )
+        )
+
+        XCTAssertTrue(script.contains("window.location.hostname"))
+        XCTAssertTrue(script.contains("ifDomainList"))
+        XCTAssertTrue(script.contains("unlessDomainList"))
+        XCTAssertTrue(script.contains("ads.example.com"))
+        XCTAssertTrue(script.contains("private.ads.example.com"))
+    }
+
+    // Verifies batched document-start scripts can carry multiple CSS blocks behind one injected style.
+    func testAndroidContentBlockerBatchedStyleInjectionScriptCombinesMultipleRules() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerBatchedStyleInjectionScript(
+                rules: [
+                    AndroidCosmeticRule(
+                        hiddenSelectors: [".first"],
+                        frameScope: AndroidCosmeticFrameScope.allFrames
+                    ),
+                    AndroidCosmeticRule(
+                        hiddenSelectors: [".second"],
+                        frameScope: AndroidCosmeticFrameScope.allFrames,
+                        urlFilterPattern: ".*\\/subframe\\.html",
+                        ifDomainList: ["ads.example.com"]
+                    )
+                ],
+                styleID: "batched-style"
+            )
+        )
+
+        XCTAssertTrue(script.contains("var rules = ["))
+        XCTAssertTrue(script.contains("\"hiddenSelectors\":[\".first\"]"))
+        XCTAssertTrue(script.contains("\"hiddenSelectors\":[\".second\"]"))
+        XCTAssertTrue(script.contains("var compactedCSS = compactHiddenSelectors(collectedSelectors)"))
+        XCTAssertTrue(script.contains("style.textContent = compactedCSS.join"))
+        XCTAssertTrue(script.contains("groupedDisplayNoneCSS"))
+        XCTAssertTrue(script.contains("compactHiddenSelectors"))
+        XCTAssertTrue(script.contains("batched-style"))
+    }
+
+    // Verifies batched document-start scripts retain per-rule frame, URL, and host guards.
+    func testAndroidContentBlockerBatchedStyleInjectionScriptRetainsRuleSpecificGuards() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerBatchedStyleInjectionScript(
+                rules: [
+                    AndroidCosmeticRule(
+                        hiddenSelectors: [".subframe"],
+                        frameScope: AndroidCosmeticFrameScope.subframesOnly,
+                        urlFilterPattern: ".*\\/subframe\\.html",
+                        ifDomainList: ["ads.example.com"],
+                        unlessDomainList: ["private.ads.example.com"]
+                    )
+                ],
+                styleID: "batched-guards"
+            )
+        )
+
+        XCTAssertTrue(script.contains("frameMatches"))
+        XCTAssertTrue(script.contains("subframesOnly"))
+        XCTAssertTrue(script.contains("new RegExp"))
+        XCTAssertTrue(script.contains("ads.example.com"))
+        XCTAssertTrue(script.contains("private.ads.example.com"))
+    }
+
+    // Verifies batched scripts merge compatible display-none rules with the same batching limits as the store reducer.
+    func testAndroidContentBlockerBatchedStyleInjectionScriptCompactsDisplayNoneCSS() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerBatchedStyleInjectionScript(
+                rules: [
+                    AndroidCosmeticRule(
+                        hiddenSelectors: [
+                            ".first",
+                            ".second",
+                            ".first"
+                        ],
+                        frameScope: AndroidCosmeticFrameScope.allFrames
+                    )
+                ],
+                styleID: "batched-compact"
+            )
+        )
+
+        XCTAssertTrue(script.contains("maximumSelectorsPerGroupedRule = 128"))
+        XCTAssertTrue(script.contains("maximumSelectorCharactersPerGroupedRule = 16384"))
+        XCTAssertTrue(script.contains("return groupedDisplayNoneCSS(uniqueSelectors)"))
+        XCTAssertTrue(script.contains("display: none !important;"))
     }
 
     // Verifies all-frame scripts omit frame guards so they can run in any frame context.

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -12,7 +12,7 @@ final class WebContentBlockerTests: XCTestCase {
 
     final class AllowAllRequestBlocker: AndroidRequestBlocker {
         func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
-            .allow
+            AndroidRequestBlockDecision.allow
         }
     }
 
@@ -26,6 +26,27 @@ final class WebContentBlockerTests: XCTestCase {
         func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
             rules
         }
+    }
+
+    final class StaticContentBlockingProvider: AndroidContentBlockingProvider {
+        let decision: AndroidRequestBlockDecision
+        let rules: [AndroidCosmeticRule]
+
+        init(decision: AndroidRequestBlockDecision = AndroidRequestBlockDecision.allow, rules: [AndroidCosmeticRule] = []) {
+            self.decision = decision
+            self.rules = rules
+        }
+
+        func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+            decision
+        }
+
+        func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+            rules
+        }
+    }
+
+    final class TestNavigationDelegate: SkipWebNavigationDelegate {
     }
 
     #if !SKIP
@@ -61,25 +82,77 @@ final class WebContentBlockerTests: XCTestCase {
     func testContentBlockerConfigurationDefaults() {
         let config = WebContentBlockerConfiguration()
         XCTAssertTrue(config.iOSRuleListPaths.isEmpty)
-        XCTAssertNil(config.androidRequestBlocker)
-        XCTAssertNil(config.androidCosmeticBlocker)
+        switch config.androidMode {
+        case .disabled:
+            break
+        case .custom:
+            XCTFail("Expected Android content blocking to default to disabled mode")
+        }
+        XCTAssertNil(config.effectiveAndroidProvider)
     }
 
     // Verifies popup child configurations retain the parent's blocker settings.
-    func testPopupChildMirroredConfigurationPreservesContentBlockers() {
+    func testPopupChildMirroredConfigurationPreservesAndroidBlockingMode() {
+        let provider = StaticContentBlockingProvider(
+            decision: AndroidRequestBlockDecision.block,
+            rules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
+        )
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
-            androidRequestBlocker: AllowAllRequestBlocker(),
-            androidCosmeticBlocker: StaticCosmeticBlocker(
-                rules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
-            )
+            androidMode: .custom(provider)
         )
         let config = WebEngineConfiguration(contentBlockers: contentBlockers)
         let mirrored = config.popupChildMirroredConfiguration()
 
         XCTAssertEqual(mirrored.contentBlockers?.iOSRuleListPaths, ["/tmp/rules.json"])
-        XCTAssertNotNil(mirrored.contentBlockers?.androidRequestBlocker)
-        XCTAssertNotNil(mirrored.contentBlockers?.androidCosmeticBlocker)
+        guard case .custom(let mirroredProvider)? = mirrored.contentBlockers?.androidMode else {
+            return XCTFail("Expected mirrored popup configuration to preserve custom Android blocking mode")
+        }
+        let mirroredDecision = mirroredProvider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: URL(string: "https://example.com")!,
+                method: "GET",
+                isForMainFrame: true,
+                hasGesture: false
+            )
+        )
+        XCTAssertEqual(mirroredDecision, AndroidRequestBlockDecision.block)
+        XCTAssertEqual(mirroredProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)).count, 1)
+    }
+
+    // Verifies legacy Android blocker hooks still bridge through the compatibility provider.
+    func testLegacyAndroidHooksBridgeToCompatibilityProvider() {
+        let contentBlockers = WebContentBlockerConfiguration(
+            androidRequestBlocker: AllowAllRequestBlocker(),
+            androidCosmeticBlocker: StaticCosmeticBlocker(
+                rules: [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
+            )
+        )
+
+        guard let provider = contentBlockers.effectiveAndroidProvider else {
+            return XCTFail("Expected legacy Android hooks to produce a compatibility provider")
+        }
+        let decision = provider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: URL(string: "https://example.com")!,
+                method: "GET",
+                isForMainFrame: true,
+                hasGesture: false
+            )
+        )
+        XCTAssertEqual(decision, AndroidRequestBlockDecision.allow)
+        XCTAssertEqual(
+            provider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
+            [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
+        )
+    }
+
+    // Verifies popup child configurations preserve the new app-facing navigation delegate.
+    func testPopupChildMirroredConfigurationPreservesNavigationDelegate() {
+        let config = WebEngineConfiguration(navigationDelegate: TestNavigationDelegate())
+        let mirrored = config.popupChildMirroredConfiguration()
+
+        XCTAssertNotNil(mirrored.navigationDelegate)
     }
 
     // Verifies Android page context derives its host from the supplied URL by default.
@@ -123,6 +196,45 @@ final class WebContentBlockerTests: XCTestCase {
     }
 
     #if SKIP
+    // Verifies assigning the deprecated engineDelegate no longer replaces the engine-owned WebViewClient.
+    func testAndroidLegacyEngineDelegateDoesNotReplaceInternalWebViewClient() {
+        let engine = WebEngine(
+            configuration: WebEngineConfiguration(
+                contentBlockers: WebContentBlockerConfiguration(
+                    androidMode: .custom(StaticContentBlockingProvider())
+                )
+            )
+        )
+        let installedClient = engine.webView.webViewClient
+        let legacyDelegate = WebEngineDelegate(config: engine.configuration)
+
+        engine.engineDelegate = legacyDelegate
+
+        XCTAssertTrue(engine.webView.webViewClient === installedClient)
+        XCTAssertTrue(engine.engineDelegate === legacyDelegate)
+    }
+
+    // Verifies a caller-supplied Android WebViewClient is forwarded through the internal engine-owned client.
+    func testAndroidSuppliedWebViewClientIsPreservedUnderInternalClient() throws {
+        let context = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().targetContext
+        let platformWebView = PlatformWebView(context)
+        let suppliedClient = android.webkit.WebViewClient()
+        platformWebView.webViewClient = suppliedClient
+
+        let engine = WebEngine(
+            configuration: WebEngineConfiguration(
+                contentBlockers: WebContentBlockerConfiguration(
+                    androidMode: .custom(StaticContentBlockingProvider())
+                )
+            ),
+            webView: platformWebView
+        )
+        let installedClient = try XCTUnwrap(engine.webView.webViewClient as? AndroidEngineWebViewClient)
+
+        XCTAssertFalse(installedClient === suppliedClient)
+        XCTAssertTrue(installedClient.embeddedNavigationClient === suppliedClient)
+    }
+
     // Verifies redirect lookup is skipped when the Android WebView runtime does not support it.
     func testAndroidRedirectDetectionSkipsLookupWhenFeatureUnsupported() {
         var resolvedRedirect = false

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -57,6 +57,16 @@ final class WebContentBlockerTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
     }
 
+    @MainActor
+    func contentBlockerFixtureDirectory(from testDirectory: URL) -> URL {
+        testDirectory.appendingPathComponent("fixtures", isDirectory: true)
+    }
+
+    @MainActor
+    func contentBlockerStoreDirectory(from testDirectory: URL) -> URL {
+        testDirectory.appendingPathComponent("store", isDirectory: true)
+    }
+
     func writeContentBlockerRuleFile(at url: URL, contents: String) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try contents.write(to: url, atomically: true, encoding: .utf8)
@@ -490,11 +500,13 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies iOS rule lists compile once and are reused from the persistent cache on subsequent loads.
     @MainActor
     func testIOSContentBlockerRuleListsCompileAndReusePersistentCache() async throws {
-        let baseDirectory = contentBlockerTestDirectory()
-        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
 
-        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
             try? WebContentBlockerDebug.clearPersistentState()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)
@@ -523,11 +535,13 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies caller-supplied WKWebView instances receive configured blocker rule lists.
     @MainActor
     func testIOSContentBlockersInstallIntoSuppliedWKWebView() async throws {
-        let baseDirectory = contentBlockerTestDirectory()
-        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
 
-        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
             try? WebContentBlockerDebug.clearPersistentState()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)
@@ -550,11 +564,13 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies changing an iOS rule file invalidates the previous compiled identifier and prunes it.
     @MainActor
     func testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier() async throws {
-        let baseDirectory = contentBlockerTestDirectory()
-        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules(filter: ".*ads-v1.*"))
 
-        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
             try? WebContentBlockerDebug.clearPersistentState()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)
@@ -584,13 +600,15 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies removing a rule file from configuration prunes its stale cached identifier.
     @MainActor
     func testIOSContentBlockerRemovingRuleFilePrunesStaleIdentifier() async throws {
-        let baseDirectory = contentBlockerTestDirectory()
-        let firstRuleFile = baseDirectory.appendingPathComponent("rules-1.json")
-        let secondRuleFile = baseDirectory.appendingPathComponent("rules-2.json")
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let firstRuleFile = fixtureDirectory.appendingPathComponent("rules-1.json")
+        let secondRuleFile = fixtureDirectory.appendingPathComponent("rules-2.json")
         try writeContentBlockerRuleFile(at: firstRuleFile, contents: validContentBlockerRules(filter: ".*ads-one.*"))
         try writeContentBlockerRuleFile(at: secondRuleFile, contents: validContentBlockerRules(filter: ".*ads-two.*"))
 
-        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
             try? WebContentBlockerDebug.clearPersistentState()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)
@@ -604,6 +622,10 @@ final class WebContentBlockerTests: XCTestCase {
         _ = await initialConfig.makeWebViewConfiguration()
         let compiledIdentifiers = WebContentBlockerDebug.diagnostics.compiledIdentifiers
         XCTAssertEqual(compiledIdentifiers.count, 2)
+      
+        guard compiledIdentifiers.count >= 2 else {
+          return
+        }
         let removedIdentifier = compiledIdentifiers[1]
 
         WebContentBlockerDebug.resetDiagnostics()
@@ -620,11 +642,13 @@ final class WebContentBlockerTests: XCTestCase {
     // Verifies invalid iOS rule files surface setup errors without aborting configuration creation.
     @MainActor
     func testIOSContentBlockerSetupErrorsAreRecordedWithoutFailingConfiguration() async throws {
-        let baseDirectory = contentBlockerTestDirectory()
-        let invalidRuleFile = baseDirectory.appendingPathComponent("invalid-rules.json")
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let invalidRuleFile = fixtureDirectory.appendingPathComponent("invalid-rules.json")
         try writeContentBlockerRuleFile(at: invalidRuleFile, contents: "[{\"trigger\":{},\"action\":{\"type\":\"block\"}}]")
 
-        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
             try? WebContentBlockerDebug.clearPersistentState()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -11,24 +11,6 @@ import WebKit
 final class WebContentBlockerTests: XCTestCase {
     #if SKIP || os(iOS)
 
-    final class AllowAllRequestBlocker: AndroidRequestBlocker {
-        func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
-            AndroidRequestBlockDecision.allow
-        }
-    }
-
-    final class StaticCosmeticBlocker: AndroidCosmeticBlocker {
-        let rules: [AndroidCosmeticRule]
-
-        init(rules: [AndroidCosmeticRule]) {
-            self.rules = rules
-        }
-
-        func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-            rules
-        }
-    }
-
     final class StaticContentBlockingProvider: AndroidContentBlockingProvider {
         let decision: AndroidRequestBlockDecision
         let persistentRules: [AndroidCosmeticRule]
@@ -104,6 +86,7 @@ final class WebContentBlockerTests: XCTestCase {
         let config = WebContentBlockerConfiguration()
         XCTAssertTrue(config.iOSRuleListPaths.isEmpty)
         XCTAssertTrue(config.whitelistedDomains.isEmpty)
+        XCTAssertTrue(config.popupWhitelistedSourceDomains.isEmpty)
         switch config.androidMode {
         case .disabled:
             break
@@ -122,6 +105,7 @@ final class WebContentBlockerTests: XCTestCase {
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
             whitelistedDomains: ["example.com"],
+            popupWhitelistedSourceDomains: ["popup.example.com"],
             androidMode: .custom(provider)
         )
         let config = WebEngineConfiguration(contentBlockers: contentBlockers)
@@ -129,6 +113,7 @@ final class WebContentBlockerTests: XCTestCase {
 
         XCTAssertEqual(mirrored.contentBlockers?.iOSRuleListPaths, ["/tmp/rules.json"])
         XCTAssertEqual(mirrored.contentBlockers?.whitelistedDomains, ["example.com"])
+        XCTAssertEqual(mirrored.contentBlockers?.popupWhitelistedSourceDomains, ["popup.example.com"])
         guard case .custom(let mirroredProvider)? = mirrored.contentBlockers?.androidMode else {
             return XCTFail("Expected mirrored popup configuration to preserve custom Android blocking mode")
         }
@@ -142,33 +127,6 @@ final class WebContentBlockerTests: XCTestCase {
         )
         XCTAssertEqual(mirroredDecision, AndroidRequestBlockDecision.block)
         XCTAssertEqual(mirroredProvider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)).count, 1)
-    }
-
-    // Verifies legacy Android blocker hooks still bridge through the compatibility provider.
-    func testLegacyAndroidHooksBridgeToCompatibilityProvider() {
-        let contentBlockers = WebContentBlockerConfiguration(
-            androidRequestBlocker: AllowAllRequestBlocker(),
-            androidCosmeticBlocker: StaticCosmeticBlocker(
-                rules: [AndroidCosmeticRule(hiddenSelectors: [".legacy"])]
-            )
-        )
-
-        guard let provider = contentBlockers.effectiveAndroidProvider else {
-            return XCTFail("Expected legacy Android hooks to produce a compatibility provider")
-        }
-        let decision = provider.requestDecision(
-            for: AndroidBlockableRequest(
-                url: URL(string: "https://example.com")!,
-                method: "GET",
-                isForMainFrame: true,
-                hasGesture: false
-            )
-        )
-        XCTAssertEqual(decision, AndroidRequestBlockDecision.allow)
-        XCTAssertEqual(
-            provider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
-            [AndroidCosmeticRule(hiddenSelectors: [".legacy"])]
-        )
     }
 
     // Verifies whitelist entries normalize for stable matching and cache behavior.
@@ -830,7 +788,7 @@ final class WebContentBlockerTests: XCTestCase {
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
         )
 
-        let errors = await config.prepareContentBlockers()
+        let errors = await config.iOSPrepareContentBlockers()
 
         XCTAssertTrue(errors.isEmpty)
         XCTAssertTrue(config.contentBlockerSetupErrors.isEmpty)
@@ -854,6 +812,36 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(appendedRule["comment"] as? String, "user-injected domain exemptions (whitelisted domains)")
         XCTAssertEqual(trigger["url-filter"] as? String, ".*")
         XCTAssertEqual(trigger["if-domain"] as? [String], ["*.example.com", "example.com"])
+        XCTAssertEqual(action["type"] as? String, "ignore-previous-rules")
+    }
+
+    // Verifies popup-only iOS whitelist rules append as popup-scoped ignore-previous-rules exemptions.
+    @MainActor
+    func testIOSPopupWhitelistedSourceDomainsAppendPopupIgnorePreviousRules() throws {
+        let augmentedContent = WebContentBlockerDebug.augmentedRuleListContent(
+            validContentBlockerRules(),
+            whitelistedDomains: [],
+            popupWhitelistedSourceDomains: [" Example.com "]
+        )
+        let data = try XCTUnwrap(augmentedContent.data(using: .utf8))
+        let jsonObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let appendedRule = try XCTUnwrap(jsonObject.last)
+        let trigger = try XCTUnwrap(appendedRule["trigger"] as? [String: Any])
+        let action = try XCTUnwrap(appendedRule["action"] as? [String: Any])
+
+        XCTAssertEqual(appendedRule["comment"] as? String, "user-injected popup exemptions (allowed source domains)")
+        XCTAssertEqual(trigger["url-filter"] as? String, ".*")
+        XCTAssertEqual(trigger["resource-type"] as? [String], ["popup"])
+        XCTAssertEqual(
+            trigger["if-top-url"] as? [String],
+            [
+                "http://*.example.com/*",
+                "http://example.com/*",
+                "https://*.example.com/*",
+                "https://example.com/*",
+            ]
+        )
+        XCTAssertNil(trigger["if-domain"])
         XCTAssertEqual(action["type"] as? String, "ignore-previous-rules")
     }
 
@@ -897,10 +885,10 @@ final class WebContentBlockerTests: XCTestCase {
 
         WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
         defer {
-            try? WebEngineConfiguration.clearContentBlockerCache()
+            try? WebEngineConfiguration.iOSClearContentBlockerCache()
             WebContentBlockerDebug.setBaseDirectoryOverride(nil)
         }
-        try? WebEngineConfiguration.clearContentBlockerCache()
+        try? WebEngineConfiguration.iOSClearContentBlockerCache()
         WebContentBlockerDebug.resetDiagnostics()
 
         let initialConfig = WebEngineConfiguration(
@@ -910,7 +898,7 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertTrue(initialConfig.contentBlockerSetupErrors.isEmpty)
         let compiledIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
 
-        try WebEngineConfiguration.clearContentBlockerCache()
+        try WebEngineConfiguration.iOSClearContentBlockerCache()
         WebContentBlockerDebug.resetDiagnostics()
 
         let reloadedConfig = WebEngineConfiguration(
@@ -996,6 +984,87 @@ final class WebContentBlockerTests: XCTestCase {
             contentBlockers: WebContentBlockerConfiguration(
                 iOSRuleListPaths: [ruleFile.path],
                 whitelistedDomains: ["*.example.com", "example.com"]
+            )
+        )
+        _ = await secondConfig.makeWebViewConfiguration()
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
+    }
+
+    // Verifies popup-only iOS whitelist entries participate in the compiled rule-list identifier.
+    @MainActor
+    func testIOSPopupWhitelistedSourceDomainsChangeInvalidateCachedIdentifier() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                popupWhitelistedSourceDomains: ["example.com"]
+            )
+        )
+        _ = await firstConfig.makeWebViewConfiguration()
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                popupWhitelistedSourceDomains: ["other.example.com"]
+            )
+        )
+        _ = await secondConfig.makeWebViewConfiguration()
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        let secondIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        XCTAssertNotEqual(firstIdentifier, secondIdentifier)
+        XCTAssertTrue(WebContentBlockerDebug.diagnostics.prunedIdentifiers.contains(firstIdentifier))
+    }
+
+    // Verifies normalized popup-only iOS whitelist entries reuse the persistent cache across semantically identical inputs.
+    @MainActor
+    func testIOSPopupWhitelistedSourceDomainsNormalizeBeforeCacheLookup() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                popupWhitelistedSourceDomains: [" Example.com ", "example.com"]
+            )
+        )
+        _ = await firstConfig.makeWebViewConfiguration()
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                popupWhitelistedSourceDomains: ["example.com"]
             )
         )
         _ = await secondConfig.makeWebViewConfiguration()

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -489,7 +489,7 @@ final class WebContentBlockerTests: XCTestCase {
     #if !SKIP
     // Verifies iOS rule lists compile once and are reused from the persistent cache on subsequent loads.
     @MainActor
-    func testIOSContentBlockerRuleListsCompileAndReusePersistentCache() throws {
+    func testIOSContentBlockerRuleListsCompileAndReusePersistentCache() async throws {
         let baseDirectory = contentBlockerTestDirectory()
         let ruleFile = baseDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
@@ -505,7 +505,7 @@ final class WebContentBlockerTests: XCTestCase {
         let firstConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
         )
-        _ = firstConfig.webViewConfiguration
+        _ = await firstConfig.makeWebViewConfiguration()
         XCTAssertTrue(firstConfig.contentBlockerSetupErrors.isEmpty)
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.compiledIdentifiers.count, 1)
         let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
@@ -515,14 +515,14 @@ final class WebContentBlockerTests: XCTestCase {
         let secondConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
         )
-        _ = secondConfig.webViewConfiguration
+        _ = await secondConfig.makeWebViewConfiguration()
         XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
     }
 
     // Verifies caller-supplied WKWebView instances receive configured blocker rule lists.
     @MainActor
-    func testIOSContentBlockersInstallIntoSuppliedWKWebView() throws {
+    func testIOSContentBlockersInstallIntoSuppliedWKWebView() async throws {
         let baseDirectory = contentBlockerTestDirectory()
         let ruleFile = baseDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
@@ -541,6 +541,7 @@ final class WebContentBlockerTests: XCTestCase {
         let existingWebView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
 
         let engine = WebEngine(configuration: config, webView: existingWebView)
+        _ = await engine.awaitContentBlockerSetup()
 
         XCTAssertTrue(engine.contentBlockerSetupErrors.isEmpty)
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.installedRuleListCount, 1)
@@ -548,7 +549,7 @@ final class WebContentBlockerTests: XCTestCase {
 
     // Verifies changing an iOS rule file invalidates the previous compiled identifier and prunes it.
     @MainActor
-    func testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier() throws {
+    func testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier() async throws {
         let baseDirectory = contentBlockerTestDirectory()
         let ruleFile = baseDirectory.appendingPathComponent("rules.json")
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules(filter: ".*ads-v1.*"))
@@ -564,7 +565,7 @@ final class WebContentBlockerTests: XCTestCase {
         let firstConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
         )
-        _ = firstConfig.webViewConfiguration
+        _ = await firstConfig.makeWebViewConfiguration()
         let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
 
         try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules(filter: ".*ads-v2.*"))
@@ -573,7 +574,7 @@ final class WebContentBlockerTests: XCTestCase {
         let secondConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
         )
-        _ = secondConfig.webViewConfiguration
+        _ = await secondConfig.makeWebViewConfiguration()
         XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
         let secondIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
         XCTAssertNotEqual(firstIdentifier, secondIdentifier)
@@ -582,7 +583,7 @@ final class WebContentBlockerTests: XCTestCase {
 
     // Verifies removing a rule file from configuration prunes its stale cached identifier.
     @MainActor
-    func testIOSContentBlockerRemovingRuleFilePrunesStaleIdentifier() throws {
+    func testIOSContentBlockerRemovingRuleFilePrunesStaleIdentifier() async throws {
         let baseDirectory = contentBlockerTestDirectory()
         let firstRuleFile = baseDirectory.appendingPathComponent("rules-1.json")
         let secondRuleFile = baseDirectory.appendingPathComponent("rules-2.json")
@@ -600,7 +601,7 @@ final class WebContentBlockerTests: XCTestCase {
         let initialConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [firstRuleFile.path, secondRuleFile.path])
         )
-        _ = initialConfig.webViewConfiguration
+        _ = await initialConfig.makeWebViewConfiguration()
         let compiledIdentifiers = WebContentBlockerDebug.diagnostics.compiledIdentifiers
         XCTAssertEqual(compiledIdentifiers.count, 2)
         let removedIdentifier = compiledIdentifiers[1]
@@ -610,7 +611,7 @@ final class WebContentBlockerTests: XCTestCase {
         let prunedConfig = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [firstRuleFile.path])
         )
-        _ = prunedConfig.webViewConfiguration
+        _ = await prunedConfig.makeWebViewConfiguration()
 
         XCTAssertTrue(prunedConfig.contentBlockerSetupErrors.isEmpty)
         XCTAssertTrue(WebContentBlockerDebug.diagnostics.prunedIdentifiers.contains(removedIdentifier))
@@ -618,7 +619,7 @@ final class WebContentBlockerTests: XCTestCase {
 
     // Verifies invalid iOS rule files surface setup errors without aborting configuration creation.
     @MainActor
-    func testIOSContentBlockerSetupErrorsAreRecordedWithoutFailingConfiguration() throws {
+    func testIOSContentBlockerSetupErrorsAreRecordedWithoutFailingConfiguration() async throws {
         let baseDirectory = contentBlockerTestDirectory()
         let invalidRuleFile = baseDirectory.appendingPathComponent("invalid-rules.json")
         try writeContentBlockerRuleFile(at: invalidRuleFile, contents: "[{\"trigger\":{},\"action\":{\"type\":\"block\"}}]")
@@ -634,7 +635,7 @@ final class WebContentBlockerTests: XCTestCase {
         let config = WebEngineConfiguration(
             contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [invalidRuleFile.path])
         )
-        _ = config.webViewConfiguration
+        _ = await config.makeWebViewConfiguration()
 
         XCTAssertEqual(config.contentBlockerSetupErrors.count, 1)
         guard case .compilationFailed(let path, _) = try XCTUnwrap(config.contentBlockerSetupErrors.first) else {

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -31,19 +31,29 @@ final class WebContentBlockerTests: XCTestCase {
 
     final class StaticContentBlockingProvider: AndroidContentBlockingProvider {
         let decision: AndroidRequestBlockDecision
-        let rules: [AndroidCosmeticRule]
+        let persistentRules: [AndroidCosmeticRule]
+        let navigationRules: [AndroidCosmeticRule]
 
-        init(decision: AndroidRequestBlockDecision = AndroidRequestBlockDecision.allow, rules: [AndroidCosmeticRule] = []) {
+        init(
+            decision: AndroidRequestBlockDecision = AndroidRequestBlockDecision.allow,
+            persistentRules: [AndroidCosmeticRule] = [],
+            navigationRules: [AndroidCosmeticRule] = []
+        ) {
             self.decision = decision
-            self.rules = rules
+            self.persistentRules = persistentRules
+            self.navigationRules = navigationRules
+        }
+
+        var persistentCosmeticRules: [AndroidCosmeticRule] {
+            persistentRules
         }
 
         func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
             decision
         }
 
-        func cosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
-            rules
+        func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+            navigationRules
         }
     }
 
@@ -107,7 +117,7 @@ final class WebContentBlockerTests: XCTestCase {
     func testPopupChildMirroredConfigurationPreservesAndroidBlockingMode() {
         let provider = StaticContentBlockingProvider(
             decision: AndroidRequestBlockDecision.block,
-            rules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
+            navigationRules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
         )
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
@@ -131,7 +141,7 @@ final class WebContentBlockerTests: XCTestCase {
             )
         )
         XCTAssertEqual(mirroredDecision, AndroidRequestBlockDecision.block)
-        XCTAssertEqual(mirroredProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)).count, 1)
+        XCTAssertEqual(mirroredProvider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)).count, 1)
     }
 
     // Verifies legacy Android blocker hooks still bridge through the compatibility provider.
@@ -156,7 +166,7 @@ final class WebContentBlockerTests: XCTestCase {
         )
         XCTAssertEqual(decision, AndroidRequestBlockDecision.allow)
         XCTAssertEqual(
-            provider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
+            provider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
             [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
         )
     }
@@ -216,10 +226,10 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(mainFrameFallbackDecision, AndroidRequestBlockDecision.allow)
     }
 
-    // Verifies Android cosmetic rules are suppressed for whitelisted page domains.
-    func testAndroidWhitelistedDomainsSuppressCosmeticRules() {
+    // Verifies whitelist wrapping no longer suppresses cosmetics at the provider layer.
+    func testAndroidWhitelistedDomainsDoNotSuppressProviderCosmeticRules() {
         let provider = StaticContentBlockingProvider(
-            rules: [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
+            navigationRules: [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
         )
         let contentBlockers = WebContentBlockerConfiguration(
             whitelistedDomains: ["example.com"],
@@ -231,15 +241,18 @@ final class WebContentBlockerTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            effectiveProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com/page")!)),
-            [AndroidCosmeticRule]()
+            effectiveProvider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com/page")!)),
+            [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
         )
     }
 
     // Verifies Android non-whitelisted domains still use the underlying provider unchanged.
     func testAndroidNonWhitelistedDomainsStillUseUnderlyingProvider() {
         let rule = AndroidCosmeticRule(css: [".ad { display: none !important; }"])
-        let provider = StaticContentBlockingProvider(decision: AndroidRequestBlockDecision.block, rules: [rule])
+        let provider = StaticContentBlockingProvider(
+            decision: AndroidRequestBlockDecision.block,
+            navigationRules: [rule]
+        )
         let contentBlockers = WebContentBlockerConfiguration(
             whitelistedDomains: ["example.com"],
             androidMode: .custom(provider)
@@ -260,7 +273,7 @@ final class WebContentBlockerTests: XCTestCase {
         )
         XCTAssertEqual(decision, AndroidRequestBlockDecision.block)
         XCTAssertEqual(
-            effectiveProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://news.other.com/article")!)),
+            effectiveProvider.navigationCosmeticRules(for: AndroidPageContext(url: URL(string: "https://news.other.com/article")!)),
             [rule]
         )
     }
@@ -640,6 +653,35 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
     }
 
+    // Verifies apps can prewarm iOS rule-list compilation without constructing WebKit controller objects.
+    @MainActor
+    func testIOSContentBlockersCanBePreparedWithoutWebViewConfiguration() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let config = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+
+        let errors = await config.prepareContentBlockers()
+
+        XCTAssertTrue(errors.isEmpty)
+        XCTAssertTrue(config.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.compiledIdentifiers.count, 1)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.installedRuleListCount, 0)
+    }
+
     // Verifies iOS whitelist rules are appended as ignore-previous-rules exemptions.
     @MainActor
     func testIOSWhitelistedDomainsAppendIgnorePreviousRules() throws {
@@ -910,6 +952,33 @@ final class WebContentBlockerTests: XCTestCase {
             return XCTFail("Expected a compilationFailed error")
         }
         XCTAssertEqual(path, invalidRuleFile.path)
+    }
+
+    // Verifies an iOS rule file that contains an empty array is treated as a no-op instead of a compilation failure.
+    @MainActor
+    func testIOSEmptyRuleListIsIgnored() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let emptyRuleFile = fixtureDirectory.appendingPathComponent("empty-rules.json")
+        try writeContentBlockerRuleFile(at: emptyRuleFile, contents: "[]")
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let config = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [emptyRuleFile.path])
+        )
+        _ = await config.makeWebViewConfiguration()
+
+        XCTAssertTrue(config.contentBlockerSetupErrors.isEmpty)
+        XCTAssertTrue(WebContentBlockerDebug.diagnostics.compiledIdentifiers.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.installedRuleListCount, 0)
     }
     #endif
     #endif

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
+// Copyright 2023-2026 Skip
+// SPDX-License-Identifier: MPL-2.0
 import XCTest
 import Foundation
 #if !SKIP

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -93,6 +93,7 @@ final class WebContentBlockerTests: XCTestCase {
     func testContentBlockerConfigurationDefaults() {
         let config = WebContentBlockerConfiguration()
         XCTAssertTrue(config.iOSRuleListPaths.isEmpty)
+        XCTAssertTrue(config.whitelistedDomains.isEmpty)
         switch config.androidMode {
         case .disabled:
             break
@@ -110,12 +111,14 @@ final class WebContentBlockerTests: XCTestCase {
         )
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
+            whitelistedDomains: ["example.com"],
             androidMode: .custom(provider)
         )
         let config = WebEngineConfiguration(contentBlockers: contentBlockers)
         let mirrored = config.popupChildMirroredConfiguration()
 
         XCTAssertEqual(mirrored.contentBlockers?.iOSRuleListPaths, ["/tmp/rules.json"])
+        XCTAssertEqual(mirrored.contentBlockers?.whitelistedDomains, ["example.com"])
         guard case .custom(let mirroredProvider)? = mirrored.contentBlockers?.androidMode else {
             return XCTFail("Expected mirrored popup configuration to preserve custom Android blocking mode")
         }
@@ -155,6 +158,110 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(
             provider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com")!)),
             [AndroidCosmeticRule(css: [".legacy { display: none !important; }"])]
+        )
+    }
+
+    // Verifies whitelist entries normalize for stable matching and cache behavior.
+    func testWhitelistedDomainsNormalizeForStableBehavior() {
+        let contentBlockers = WebContentBlockerConfiguration(
+            whitelistedDomains: [" Example.com ", "*.Example.com", "example.com", ""]
+        )
+
+        XCTAssertEqual(contentBlockers.normalizedWhitelistedDomains, ["*.example.com", "example.com"])
+    }
+
+    // Verifies exact and wildcard whitelist rules retain WebKit-style matching semantics.
+    func testWhitelistedDomainsMatchExactAndWildcardHosts() {
+        let domains = WebContentBlockerConfiguration.normalizedWhitelistedDomains(
+            from: ["example.com", "*.example.com"]
+        )
+
+        XCTAssertTrue(WebContentBlockerConfiguration.matchesWhitelistedDomain("example.com", in: domains))
+        XCTAssertTrue(WebContentBlockerConfiguration.matchesWhitelistedDomain("news.example.com", in: domains))
+        XCTAssertFalse(WebContentBlockerConfiguration.matchesWhitelistedDomain("deep.news.other.com", in: domains))
+        XCTAssertFalse(WebContentBlockerConfiguration.matchesWhitelistedDomain("otherexample.com", in: domains))
+    }
+
+    // Verifies Android request blocking is bypassed for whitelisted page domains.
+    func testAndroidWhitelistedDomainsBypassRequestBlocking() {
+        let provider = StaticContentBlockingProvider(decision: .block)
+        let contentBlockers = WebContentBlockerConfiguration(
+            whitelistedDomains: ["example.com", "*.example.net"],
+            androidMode: .custom(provider)
+        )
+
+        guard let effectiveProvider = contentBlockers.effectiveAndroidProvider else {
+            return XCTFail("Expected effective Android provider")
+        }
+
+        let mainDocumentDecision = effectiveProvider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: URL(string: "https://cdn.ads.net/script.js")!,
+                mainDocumentURL: URL(string: "https://example.com/article")!,
+                method: "GET",
+                isForMainFrame: false,
+                hasGesture: false
+            )
+        )
+        XCTAssertEqual(mainDocumentDecision, AndroidRequestBlockDecision.allow)
+
+        let mainFrameFallbackDecision = effectiveProvider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: URL(string: "https://sub.example.net/home")!,
+                method: "GET",
+                isForMainFrame: true,
+                hasGesture: false
+            )
+        )
+        XCTAssertEqual(mainFrameFallbackDecision, AndroidRequestBlockDecision.allow)
+    }
+
+    // Verifies Android cosmetic rules are suppressed for whitelisted page domains.
+    func testAndroidWhitelistedDomainsSuppressCosmeticRules() {
+        let provider = StaticContentBlockingProvider(
+            rules: [AndroidCosmeticRule(css: [".ad { display: none !important; }"])]
+        )
+        let contentBlockers = WebContentBlockerConfiguration(
+            whitelistedDomains: ["example.com"],
+            androidMode: .custom(provider)
+        )
+
+        guard let effectiveProvider = contentBlockers.effectiveAndroidProvider else {
+            return XCTFail("Expected effective Android provider")
+        }
+
+        XCTAssertEqual(
+            effectiveProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://example.com/page")!)),
+            [AndroidCosmeticRule]()
+        )
+    }
+
+    // Verifies Android non-whitelisted domains still use the underlying provider unchanged.
+    func testAndroidNonWhitelistedDomainsStillUseUnderlyingProvider() {
+        let rule = AndroidCosmeticRule(css: [".ad { display: none !important; }"])
+        let provider = StaticContentBlockingProvider(decision: AndroidRequestBlockDecision.block, rules: [rule])
+        let contentBlockers = WebContentBlockerConfiguration(
+            whitelistedDomains: ["example.com"],
+            androidMode: .custom(provider)
+        )
+
+        guard let effectiveProvider = contentBlockers.effectiveAndroidProvider else {
+            return XCTFail("Expected effective Android provider")
+        }
+
+        let decision = effectiveProvider.requestDecision(
+            for: AndroidBlockableRequest(
+                url: URL(string: "https://cdn.ads.net/script.js")!,
+                mainDocumentURL: URL(string: "https://news.other.com/article")!,
+                method: "GET",
+                isForMainFrame: false,
+                hasGesture: false
+            )
+        )
+        XCTAssertEqual(decision, AndroidRequestBlockDecision.block)
+        XCTAssertEqual(
+            effectiveProvider.cosmeticRules(for: AndroidPageContext(url: URL(string: "https://news.other.com/article")!)),
+            [rule]
         )
     }
 
@@ -533,6 +640,25 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
     }
 
+    // Verifies iOS whitelist rules are appended as ignore-previous-rules exemptions.
+    @MainActor
+    func testIOSWhitelistedDomainsAppendIgnorePreviousRules() throws {
+        let augmentedContent = WebContentBlockerDebug.augmentedRuleListContent(
+            validContentBlockerRules(),
+            whitelistedDomains: [" Example.com ", "*.Example.com"]
+        )
+        let data = try XCTUnwrap(augmentedContent.data(using: .utf8))
+        let jsonObject = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [[String: Any]])
+        let appendedRule = try XCTUnwrap(jsonObject.last)
+        let trigger = try XCTUnwrap(appendedRule["trigger"] as? [String: Any])
+        let action = try XCTUnwrap(appendedRule["action"] as? [String: Any])
+
+        XCTAssertEqual(appendedRule["comment"] as? String, "user-injected domain exemptions (whitelisted domains)")
+        XCTAssertEqual(trigger["url-filter"] as? String, ".*")
+        XCTAssertEqual(trigger["if-domain"] as? [String], ["*.example.com", "example.com"])
+        XCTAssertEqual(action["type"] as? String, "ignore-previous-rules")
+    }
+
     // Verifies caller-supplied WKWebView instances receive configured blocker rule lists.
     @MainActor
     func testIOSContentBlockersInstallIntoSuppliedWKWebView() async throws {
@@ -596,6 +722,87 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertTrue(reloadedConfig.contentBlockerSetupErrors.isEmpty)
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [])
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.compiledIdentifiers, [compiledIdentifier])
+    }
+
+    // Verifies changing the whitelist invalidates the cached iOS compiled identifier.
+    @MainActor
+    func testIOSWhitelistedDomainsInvalidateCachedIdentifierWhenChanged() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                whitelistedDomains: ["example.com"]
+            )
+        )
+        _ = await firstConfig.makeWebViewConfiguration()
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                whitelistedDomains: ["other.example.com"]
+            )
+        )
+        _ = await secondConfig.makeWebViewConfiguration()
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        let secondIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        XCTAssertNotEqual(firstIdentifier, secondIdentifier)
+        XCTAssertTrue(WebContentBlockerDebug.diagnostics.prunedIdentifiers.contains(firstIdentifier))
+    }
+
+    // Verifies normalized iOS whitelist entries reuse the persistent cache across semantically identical inputs.
+    @MainActor
+    func testIOSWhitelistedDomainsNormalizeBeforeCacheLookup() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                whitelistedDomains: [" Example.com ", "example.com", "*.Example.com"]
+            )
+        )
+        _ = await firstConfig.makeWebViewConfiguration()
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(
+                iOSRuleListPaths: [ruleFile.path],
+                whitelistedDomains: ["*.example.com", "example.com"]
+            )
+        )
+        _ = await secondConfig.makeWebViewConfiguration()
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
     }
 
     // Verifies changing an iOS rule file invalidates the previous compiled identifier and prunes it.

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: LGPL-3.0-only WITH LGPL-3.0-linking-exception
+import XCTest
+import Foundation
+#if !SKIP
+import WebKit
+#endif
+@testable import SkipWeb
+
+// SKIP INSERT: @androidx.test.annotation.UiThreadTest
+final class WebContentBlockerTests: XCTestCase {
+    #if SKIP || os(iOS)
+
+    final class AllowAllRequestBlocker: AndroidRequestBlocker {
+        func decision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
+            .allow
+        }
+    }
+
+    final class StaticCosmeticBlocker: AndroidCosmeticBlocker {
+        let payload: AndroidCosmeticPayload
+
+        init(payload: AndroidCosmeticPayload) {
+            self.payload = payload
+        }
+
+        func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload? {
+            payload
+        }
+    }
+
+    #if !SKIP
+    @MainActor
+    func contentBlockerTestDirectory() -> URL {
+        URL.temporaryDirectory
+            .appendingPathComponent("skipweb-content-blocker-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+
+    func writeContentBlockerRuleFile(at url: URL, contents: String) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    func validContentBlockerRules(filter: String = ".*ads.*") -> String {
+        """
+        [
+          {
+            "trigger": {
+              "url-filter": "\(filter)"
+            },
+            "action": {
+              "type": "block"
+            }
+          }
+        ]
+        """
+    }
+    #endif
+
+    // Verifies content blocker configuration starts with no platform-specific blockers configured.
+    func testContentBlockerConfigurationDefaults() {
+        let config = WebContentBlockerConfiguration()
+        XCTAssertTrue(config.iOSRuleListPaths.isEmpty)
+        XCTAssertNil(config.androidRequestBlocker)
+        XCTAssertNil(config.androidCosmeticBlocker)
+    }
+
+    // Verifies popup child configurations retain the parent's blocker settings.
+    func testPopupChildMirroredConfigurationPreservesContentBlockers() {
+        let contentBlockers = WebContentBlockerConfiguration(
+            iOSRuleListPaths: ["/tmp/rules.json"],
+            androidRequestBlocker: AllowAllRequestBlocker(),
+            androidCosmeticBlocker: StaticCosmeticBlocker(payload: AndroidCosmeticPayload(css: [".ad{display:none!important;}"]))
+        )
+        let config = WebEngineConfiguration(contentBlockers: contentBlockers)
+        let mirrored = config.popupChildMirroredConfiguration()
+
+        XCTAssertEqual(mirrored.contentBlockers?.iOSRuleListPaths, ["/tmp/rules.json"])
+        XCTAssertNotNil(mirrored.contentBlockers?.androidRequestBlocker)
+        XCTAssertNotNil(mirrored.contentBlockers?.androidCosmeticBlocker)
+    }
+
+    // Verifies Android page context derives its host from the supplied URL by default.
+    func testAndroidPageContextDefaultsHostFromURL() throws {
+        let pageURL = try XCTUnwrap(URL(string: "https://example.com/path"))
+        let context = AndroidPageContext(url: pageURL)
+        XCTAssertEqual(context.host, "example.com")
+    }
+
+    #if SKIP
+    // Verifies redirect lookup is skipped when the Android WebView runtime does not support it.
+    func testAndroidRedirectDetectionSkipsLookupWhenFeatureUnsupported() {
+        var resolvedRedirect = false
+
+        let redirect = WebEngine.androidRedirectFlag(isRedirectFeatureSupported: false) {
+            resolvedRedirect = true
+            return true
+        }
+
+        XCTAssertNil(redirect)
+        XCTAssertFalse(resolvedRedirect)
+    }
+    #endif
+
+    #if !SKIP
+    // Verifies iOS rule lists compile once and are reused from the persistent cache on subsequent loads.
+    @MainActor
+    func testIOSContentBlockerRuleListsCompileAndReusePersistentCache() throws {
+        let baseDirectory = contentBlockerTestDirectory()
+        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = firstConfig.webViewConfiguration
+        XCTAssertTrue(firstConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.compiledIdentifiers.count, 1)
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = secondConfig.webViewConfiguration
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [firstIdentifier])
+    }
+
+    // Verifies caller-supplied WKWebView instances receive configured blocker rule lists.
+    @MainActor
+    func testIOSContentBlockersInstallIntoSuppliedWKWebView() throws {
+        let baseDirectory = contentBlockerTestDirectory()
+        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let config = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        let existingWebView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+
+        let engine = WebEngine(configuration: config, webView: existingWebView)
+
+        XCTAssertTrue(engine.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.installedRuleListCount, 1)
+    }
+
+    // Verifies changing an iOS rule file invalidates the previous compiled identifier and prunes it.
+    @MainActor
+    func testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier() throws {
+        let baseDirectory = contentBlockerTestDirectory()
+        let ruleFile = baseDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules(filter: ".*ads-v1.*"))
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let firstConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = firstConfig.webViewConfiguration
+        let firstIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules(filter: ".*ads-v2.*"))
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let secondConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = secondConfig.webViewConfiguration
+        XCTAssertTrue(secondConfig.contentBlockerSetupErrors.isEmpty)
+        let secondIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+        XCTAssertNotEqual(firstIdentifier, secondIdentifier)
+        XCTAssertTrue(WebContentBlockerDebug.diagnostics.prunedIdentifiers.contains(firstIdentifier))
+    }
+
+    // Verifies removing a rule file from configuration prunes its stale cached identifier.
+    @MainActor
+    func testIOSContentBlockerRemovingRuleFilePrunesStaleIdentifier() throws {
+        let baseDirectory = contentBlockerTestDirectory()
+        let firstRuleFile = baseDirectory.appendingPathComponent("rules-1.json")
+        let secondRuleFile = baseDirectory.appendingPathComponent("rules-2.json")
+        try writeContentBlockerRuleFile(at: firstRuleFile, contents: validContentBlockerRules(filter: ".*ads-one.*"))
+        try writeContentBlockerRuleFile(at: secondRuleFile, contents: validContentBlockerRules(filter: ".*ads-two.*"))
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let initialConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [firstRuleFile.path, secondRuleFile.path])
+        )
+        _ = initialConfig.webViewConfiguration
+        let compiledIdentifiers = WebContentBlockerDebug.diagnostics.compiledIdentifiers
+        XCTAssertEqual(compiledIdentifiers.count, 2)
+        let removedIdentifier = compiledIdentifiers[1]
+
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let prunedConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [firstRuleFile.path])
+        )
+        _ = prunedConfig.webViewConfiguration
+
+        XCTAssertTrue(prunedConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertTrue(WebContentBlockerDebug.diagnostics.prunedIdentifiers.contains(removedIdentifier))
+    }
+
+    // Verifies invalid iOS rule files surface setup errors without aborting configuration creation.
+    @MainActor
+    func testIOSContentBlockerSetupErrorsAreRecordedWithoutFailingConfiguration() throws {
+        let baseDirectory = contentBlockerTestDirectory()
+        let invalidRuleFile = baseDirectory.appendingPathComponent("invalid-rules.json")
+        try writeContentBlockerRuleFile(at: invalidRuleFile, contents: "[{\"trigger\":{},\"action\":{\"type\":\"block\"}}]")
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(baseDirectory)
+        defer {
+            try? WebContentBlockerDebug.clearPersistentState()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebContentBlockerDebug.clearPersistentState()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let config = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [invalidRuleFile.path])
+        )
+        _ = config.webViewConfiguration
+
+        XCTAssertEqual(config.contentBlockerSetupErrors.count, 1)
+        guard case .compilationFailed(let path, _) = try XCTUnwrap(config.contentBlockerSetupErrors.first) else {
+            return XCTFail("Expected a compilationFailed error")
+        }
+        XCTAssertEqual(path, invalidRuleFile.path)
+    }
+    #endif
+    #endif
+}

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -562,6 +562,42 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(WebContentBlockerDebug.diagnostics.installedRuleListCount, 1)
     }
 
+    // Verifies the public cache-clear API removes persisted rule lists so the next load recompiles from source.
+    @MainActor
+    func testIOSContentBlockerCacheCanBeClearedExplicitly() async throws {
+        let testDirectory = contentBlockerTestDirectory()
+        let fixtureDirectory = contentBlockerFixtureDirectory(from: testDirectory)
+        let storeDirectory = contentBlockerStoreDirectory(from: testDirectory)
+        let ruleFile = fixtureDirectory.appendingPathComponent("rules.json")
+        try writeContentBlockerRuleFile(at: ruleFile, contents: validContentBlockerRules())
+
+        WebContentBlockerDebug.setBaseDirectoryOverride(storeDirectory)
+        defer {
+            try? WebEngineConfiguration.clearContentBlockerCache()
+            WebContentBlockerDebug.setBaseDirectoryOverride(nil)
+        }
+        try? WebEngineConfiguration.clearContentBlockerCache()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let initialConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = await initialConfig.makeWebViewConfiguration()
+        XCTAssertTrue(initialConfig.contentBlockerSetupErrors.isEmpty)
+        let compiledIdentifier = try XCTUnwrap(WebContentBlockerDebug.diagnostics.compiledIdentifiers.first)
+
+        try WebEngineConfiguration.clearContentBlockerCache()
+        WebContentBlockerDebug.resetDiagnostics()
+
+        let reloadedConfig = WebEngineConfiguration(
+            contentBlockers: WebContentBlockerConfiguration(iOSRuleListPaths: [ruleFile.path])
+        )
+        _ = await reloadedConfig.makeWebViewConfiguration()
+        XCTAssertTrue(reloadedConfig.contentBlockerSetupErrors.isEmpty)
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.cacheHitIdentifiers, [])
+        XCTAssertEqual(WebContentBlockerDebug.diagnostics.compiledIdentifiers, [compiledIdentifier])
+    }
+
     // Verifies changing an iOS rule file invalidates the previous compiled identifier and prunes it.
     @MainActor
     func testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier() async throws {

--- a/Tests/SkipWebTests/WebContentBlockerTests.swift
+++ b/Tests/SkipWebTests/WebContentBlockerTests.swift
@@ -17,14 +17,14 @@ final class WebContentBlockerTests: XCTestCase {
     }
 
     final class StaticCosmeticBlocker: AndroidCosmeticBlocker {
-        let payload: AndroidCosmeticPayload
+        let rules: [AndroidCosmeticRule]
 
-        init(payload: AndroidCosmeticPayload) {
-            self.payload = payload
+        init(rules: [AndroidCosmeticRule]) {
+            self.rules = rules
         }
 
-        func cosmetics(for page: AndroidPageContext) -> AndroidCosmeticPayload? {
-            payload
+        func cosmetics(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
+            rules
         }
     }
 
@@ -70,7 +70,9 @@ final class WebContentBlockerTests: XCTestCase {
         let contentBlockers = WebContentBlockerConfiguration(
             iOSRuleListPaths: ["/tmp/rules.json"],
             androidRequestBlocker: AllowAllRequestBlocker(),
-            androidCosmeticBlocker: StaticCosmeticBlocker(payload: AndroidCosmeticPayload(css: [".ad{display:none!important;}"]))
+            androidCosmeticBlocker: StaticCosmeticBlocker(
+                rules: [AndroidCosmeticRule(css: [".ad{display:none!important;}"])]
+            )
         )
         let config = WebEngineConfiguration(contentBlockers: contentBlockers)
         let mirrored = config.popupChildMirroredConfiguration()
@@ -87,6 +89,39 @@ final class WebContentBlockerTests: XCTestCase {
         XCTAssertEqual(context.host, "example.com")
     }
 
+    // Verifies Android cosmetic rules default to wildcard origins, main-frame scope, and document-start timing.
+    func testAndroidCosmeticRuleDefaults() {
+        let rule = AndroidCosmeticRule(css: [".ad { display: none !important; }"])
+
+        XCTAssertNil(rule.urlFilterPattern)
+        XCTAssertEqual(rule.allowedOriginRules, ["*"])
+        XCTAssertEqual(rule.frameScope, .mainFrameOnly)
+        XCTAssertEqual(rule.preferredTiming, .documentStart)
+    }
+
+    // Verifies selector-based convenience rules compile to display:none for iOS-style hiding.
+    func testAndroidCosmeticRuleHiddenSelectorsConvenienceInitializer() {
+        let rule = AndroidCosmeticRule(
+            hiddenSelectors: [
+                ".ad-banner",
+                " #sponsored "
+            ],
+            urlFilterPattern: ".*\\/ad-frame\\.html",
+            allowedOriginRules: ["https://*.doubleclick.net"],
+            frameScope: .subframesOnly,
+            preferredTiming: .documentStart
+        )
+
+        XCTAssertEqual(rule.css, [
+            ".ad-banner { display: none !important; }",
+            "#sponsored { display: none !important; }"
+        ])
+        XCTAssertEqual(rule.urlFilterPattern, ".*\\/ad-frame\\.html")
+        XCTAssertEqual(rule.allowedOriginRules, ["https://*.doubleclick.net"])
+        XCTAssertEqual(rule.frameScope, .subframesOnly)
+        XCTAssertEqual(rule.preferredTiming, .documentStart)
+    }
+
     #if SKIP
     // Verifies redirect lookup is skipped when the Android WebView runtime does not support it.
     func testAndroidRedirectDetectionSkipsLookupWhenFeatureUnsupported() {
@@ -99,6 +134,243 @@ final class WebContentBlockerTests: XCTestCase {
 
         XCTAssertNil(redirect)
         XCTAssertFalse(resolvedRedirect)
+    }
+
+    // Verifies back/forward navigation resolves the target history index before the Android load begins.
+    func testAndroidHistoryNavigationIndexUsesOffsetFromCurrentEntry() {
+        XCTAssertEqual(WebEngine.androidHistoryNavigationIndex(currentIndex: 2, size: 5, offset: -1), 1)
+        XCTAssertEqual(WebEngine.androidHistoryNavigationIndex(currentIndex: 2, size: 5, offset: 1), 3)
+    }
+
+    // Verifies history navigation skips cosmetic pre-registration when there is no target entry.
+    func testAndroidHistoryNavigationIndexRejectsOutOfBoundsTargets() {
+        XCTAssertNil(WebEngine.androidHistoryNavigationIndex(currentIndex: 0, size: 1, offset: -1))
+        XCTAssertNil(WebEngine.androidHistoryNavigationIndex(currentIndex: 0, size: 1, offset: 1))
+    }
+
+    // Verifies document-start cosmetic rules preserve the caller-provided ordering.
+    func testAndroidCosmeticPlanPreservesDocumentStartRuleOrder() {
+        let rules = [
+            AndroidCosmeticRule(
+                css: [".primary { display: none !important; }"],
+                allowedOriginRules: ["https://*.doubleclick.net"],
+                frameScope: .subframesOnly,
+                preferredTiming: .documentStart
+            ),
+            AndroidCosmeticRule(
+                css: [".secondary { opacity: 0 !important; }"],
+                allowedOriginRules: ["*"],
+                frameScope: .allFrames,
+                preferredTiming: .documentStart
+            )
+        ]
+
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: rules,
+            pageURL: URL(string: "https://www.example.com")!,
+            isDocumentStartSupported: true
+        )
+
+        XCTAssertEqual(plan.documentStartRules, rules)
+        XCTAssertTrue(plan.lifecycleCSS.isEmpty)
+    }
+
+    // Verifies unsupported document-start injection falls back only for main-frame rules.
+    func testAndroidCosmeticPlanFallsBackOnlyForMainFrameRulesWhenUnsupported() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".main { display: none !important; }"],
+                    preferredTiming: .documentStart
+                ),
+                AndroidCosmeticRule(
+                    css: [".subframe { display: none !important; }"],
+                    frameScope: .subframesOnly,
+                    preferredTiming: .documentStart
+                )
+            ],
+            pageURL: URL(string: "https://www.example.com")!,
+            isDocumentStartSupported: false
+        )
+
+        XCTAssertTrue(plan.documentStartRules.isEmpty)
+        XCTAssertEqual(plan.lifecycleCSS, [".main { display: none !important; }"])
+    }
+
+    // Verifies page-lifecycle injection keeps only rules that are valid for main-frame fallback.
+    func testAndroidCosmeticPlanKeepsPageLifecycleRulesForMainFrameOnly() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".late { display: none !important; }"],
+                    preferredTiming: .pageLifecycle
+                ),
+                AndroidCosmeticRule(
+                    css: [".ignored { display: none !important; }"],
+                    frameScope: .allFrames,
+                    preferredTiming: .pageLifecycle
+                )
+            ],
+            pageURL: URL(string: "https://www.example.com")!,
+            isDocumentStartSupported: true
+        )
+
+        XCTAssertTrue(plan.documentStartRules.isEmpty)
+        XCTAssertEqual(plan.lifecycleCSS, [".late { display: none !important; }"])
+    }
+
+    // Verifies page-lifecycle rules honor allowed origin scoping before injecting CSS into the main frame.
+    func testAndroidCosmeticPlanFiltersLifecycleRulesByAllowedOriginRules() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".match { display: none !important; }"],
+                    allowedOriginRules: ["https://*.example.com"],
+                    preferredTiming: .pageLifecycle
+                ),
+                AndroidCosmeticRule(
+                    css: [".skip { display: none !important; }"],
+                    allowedOriginRules: ["https://ads.example.net"],
+                    preferredTiming: .pageLifecycle
+                )
+            ],
+            pageURL: URL(string: "https://news.example.com")!,
+            isDocumentStartSupported: true
+        )
+
+        XCTAssertEqual(plan.lifecycleCSS, [".match { display: none !important; }"])
+    }
+
+    // Verifies document-start fallback keeps origin scoping when it degrades to lifecycle injection.
+    func testAndroidCosmeticPlanFiltersFallbackRulesByAllowedOriginRules() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".match { display: none !important; }"],
+                    allowedOriginRules: ["https://example.com"],
+                    preferredTiming: .documentStart
+                ),
+                AndroidCosmeticRule(
+                    css: [".skip { display: none !important; }"],
+                    allowedOriginRules: ["https://other.example.com"],
+                    preferredTiming: .documentStart
+                )
+            ],
+            pageURL: URL(string: "https://example.com")!,
+            isDocumentStartSupported: false
+        )
+
+        XCTAssertEqual(plan.lifecycleCSS, [".match { display: none !important; }"])
+    }
+
+    // Verifies lifecycle fallback also requires the main document URL to match urlFilterPattern.
+    func testAndroidCosmeticPlanFiltersFallbackRulesByURLFilterPattern() {
+        let plan = WebEngine.androidCosmeticInjectionPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".match { display: none !important; }"],
+                    urlFilterPattern: ".*\\/index\\.html",
+                    preferredTiming: .documentStart
+                ),
+                AndroidCosmeticRule(
+                    css: [".skip { display: none !important; }"],
+                    urlFilterPattern: ".*\\/subframe\\.html",
+                    preferredTiming: .documentStart
+                )
+            ],
+            pageURL: URL(string: "https://example.com/index.html")!,
+            isDocumentStartSupported: false
+        )
+
+        XCTAssertEqual(plan.lifecycleCSS, [".match { display: none !important; }"])
+    }
+
+    // Verifies redirected pages degrade document-start rules to main-frame lifecycle injection.
+    func testAndroidRedirectFallbackPlanDegradesDocumentStartRulesEvenWhenSupported() {
+        let plan = WebEngine.androidRedirectFallbackCosmeticPlan(
+            rules: [
+                AndroidCosmeticRule(
+                    css: [".main { display: none !important; }"],
+                    preferredTiming: .documentStart
+                ),
+                AndroidCosmeticRule(
+                    css: [".subframe { display: none !important; }"],
+                    frameScope: .subframesOnly,
+                    preferredTiming: .documentStart
+                )
+            ],
+            pageURL: URL(string: "https://www.example.com")!
+        )
+
+        XCTAssertTrue(plan.documentStartRules.isEmpty)
+        XCTAssertEqual(plan.lifecycleCSS, [".main { display: none !important; }"])
+    }
+
+    // Verifies main-frame-only scripts bail out when executed inside a subframe.
+    func testAndroidContentBlockerStyleInjectionScriptAddsMainFrameGuard() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerStyleInjectionScript(
+                cssRules: [".main { display: none !important; }"],
+                styleID: "main-style",
+                frameScope: AndroidCosmeticFrameScope.mainFrameOnly
+            )
+        )
+
+        XCTAssertTrue(script.contains("window.top !== window.self"))
+        XCTAssertTrue(script.contains("main-style"))
+    }
+
+    // Verifies subframe-only scripts bail out when executed in the top-level frame.
+    func testAndroidContentBlockerStyleInjectionScriptAddsSubframeGuard() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerStyleInjectionScript(
+                cssRules: [".subframe { display: none !important; }"],
+                styleID: "subframe-style",
+                frameScope: AndroidCosmeticFrameScope.subframesOnly
+            )
+        )
+
+        XCTAssertTrue(script.contains("window.top === window.self"))
+        XCTAssertTrue(script.contains("subframe-style"))
+    }
+
+    // Verifies URL-scoped scripts bail out when the frame URL does not match the provided rule pattern.
+    func testAndroidContentBlockerStyleInjectionScriptAddsURLGuard() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerStyleInjectionScript(
+                cssRules: [".subframe { display: none !important; }"],
+                styleID: "url-style",
+                frameScope: AndroidCosmeticFrameScope.allFrames,
+                urlFilterPattern: ".*\\/subframe\\.html"
+            )
+        )
+
+        XCTAssertTrue(script.contains("new RegExp"))
+        XCTAssertTrue(script.contains("window.location.href"))
+        XCTAssertTrue(script.contains("subframe\\\\.html"))
+    }
+
+    // Verifies all-frame scripts omit frame guards so they can run in any frame context.
+    func testAndroidContentBlockerStyleInjectionScriptLeavesAllFramesUngarded() throws {
+        let script = try XCTUnwrap(
+            WebEngine.androidContentBlockerStyleInjectionScript(
+                cssRules: [".shared { display: none !important; }"],
+                styleID: "shared-style",
+                frameScope: AndroidCosmeticFrameScope.allFrames
+            )
+        )
+
+        XCTAssertFalse(script.contains("window.top !== window.self"))
+        XCTAssertFalse(script.contains("window.top === window.self"))
+        XCTAssertTrue(script.contains("shared-style"))
+    }
+
+    // Verifies stale injected CSS can be removed when a redirected final page no longer matches any rules.
+    func testAndroidContentBlockerStyleRemovalScriptTargetsInjectedStyle() {
+        let script = WebEngine.androidContentBlockerStyleRemovalScript(styleID: "shared-style")
+
+        XCTAssertTrue(script.contains("document.getElementById(\"shared-style\")"))
+        XCTAssertTrue(script.contains("style.remove()"))
     }
     #endif
 

--- a/Tests/SkipWebTests/WebEngineTestSupport.swift
+++ b/Tests/SkipWebTests/WebEngineTestSupport.swift
@@ -9,7 +9,7 @@ import WebKit
 
 #if SKIP || os(iOS)
 @MainActor
-func makeCookieTestEngine(profile: WebProfile = WebProfile.default) -> WebEngine {
+func makeCookieTestEngine(profile: WebProfile = WebProfile.default) async -> WebEngine {
     let config = WebEngineConfiguration(profile: profile)
     #if SKIP
     let instrumentation = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
@@ -33,7 +33,7 @@ func makeCookieTestEngine(profile: WebProfile = WebProfile.default) -> WebEngine
         return createdEngine
     }
     #else
-    let platformWebView = PlatformWebView(frame: CGRectZero, configuration: config.webViewConfiguration)
+    let platformWebView = PlatformWebView(frame: CGRectZero, configuration: await config.makeWebViewConfiguration())
     return WebEngine(configuration: config, webView: platformWebView)
     #endif
 }

--- a/Tests/SkipWebTests/WebProfileSegregationTests.swift
+++ b/Tests/SkipWebTests/WebProfileSegregationTests.swift
@@ -24,7 +24,7 @@ final class WebProfileSegregationTests: XCTestCase {
             throw XCTSkip("WebEngine-backed navigator tests require instrumented Android context")
         }
         let navigator = WebViewNavigator()
-        navigator.webEngine = makeCookieTestEngine(profile: .named(" "))
+        navigator.webEngine = await makeCookieTestEngine(profile: .named(" "))
         let requestURL = try XCTUnwrap(URL(string: "https://invalid-profile.example.com/path"))
 
         do {
@@ -44,8 +44,8 @@ final class WebProfileSegregationTests: XCTestCase {
         let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         let profileA: WebProfile = .named("ios_profile_a_\(suffix)")
         let profileB: WebProfile = .named("ios_profile_b_\(suffix)")
-        let engineA = makeCookieTestEngine(profile: profileA)
-        let engineB = makeCookieTestEngine(profile: profileB)
+        let engineA = await makeCookieTestEngine(profile: profileA)
+        let engineB = await makeCookieTestEngine(profile: profileB)
         await engineA.clearCookies()
         await engineB.clearCookies()
 
@@ -80,8 +80,8 @@ final class WebProfileSegregationTests: XCTestCase {
     func testIOSNamedProfileSharesCookiesAcrossEnginesWithSameIdentifier() async throws {
         let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "")
         let sharedProfile: WebProfile = .named("ios_profile_shared_\(suffix)")
-        let engineA = makeCookieTestEngine(profile: sharedProfile)
-        let engineB = makeCookieTestEngine(profile: sharedProfile)
+        let engineA = await makeCookieTestEngine(profile: sharedProfile)
+        let engineB = await makeCookieTestEngine(profile: sharedProfile)
         await engineA.clearCookies()
         await engineB.clearCookies()
 
@@ -130,7 +130,7 @@ final class WebProfileSegregationTests: XCTestCase {
         if isRobolectric {
             throw XCTSkip("Android profile inheritance tests require instrumented Android context")
         }
-        let child = makeCookieTestEngine(profile: .default)
+        let child = await makeCookieTestEngine(profile: .default)
         let profileError = child.inheritAndroidProfile(from: WebProfile.named(" "))
         XCTAssertEqual(profileError, WebProfileError.invalidProfileName)
 
@@ -151,7 +151,7 @@ final class WebProfileSegregationTests: XCTestCase {
         if isRobolectric {
             throw XCTSkip("WebView feature probes are unavailable in Robolectric")
         }
-        let child = makeCookieTestEngine(profile: .default)
+        let child = await makeCookieTestEngine(profile: .default)
         let profileError = child.inheritAndroidProfile(from: WebProfile.named("android-profile-inherited"))
         if WebEngine.isAndroidMultiProfileSupported() {
             XCTAssertNil(profileError)
@@ -169,7 +169,7 @@ final class WebProfileSegregationTests: XCTestCase {
         if WebEngine.isAndroidMultiProfileSupported() {
             throw XCTSkip("device WebView runtime supports multi-profile")
         }
-        let engine = makeCookieTestEngine(profile: .named("android-profile"))
+        let engine = await makeCookieTestEngine(profile: .named("android-profile"))
         let requestURL = try XCTUnwrap(URL(string: "https://android-profile.example.com/path"))
         do {
             try await engine.setCookie(WebCookie(name: "session", value: "1"), requestURL: requestURL)
@@ -192,8 +192,8 @@ final class WebProfileSegregationTests: XCTestCase {
         }
 
         let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-        let engineA = makeCookieTestEngine(profile: .named("android_profile_a_\(suffix)"))
-        let engineB = makeCookieTestEngine(profile: .named("android_profile_b_\(suffix)"))
+        let engineA = await makeCookieTestEngine(profile: .named("android_profile_a_\(suffix)"))
+        let engineB = await makeCookieTestEngine(profile: .named("android_profile_b_\(suffix)"))
         await engineA.clearCookies()
         await engineB.clearCookies()
 


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code. Unit test all green when running locally + ran Smoke Tests from Android/iOS devices:


## Content Blocking Smoke Suite

### Smoke Tests Summary
These smoke tests focus on four higher-level areas:

- Configuration and propagation: default blocker state and inheritance into popup child engines.
- Android navigation client ownership: preserving caller-supplied clients while keeping blocker enforcement active.
- Android cosmetic planning and script generation: rule defaults, URL/origin/frame filtering, history/redirect handling, and generated CSS injection/removal scripts.
- iOS rule-list lifecycle: compilation, cache reuse, installation into `WKWebView`, cache invalidation, and pruning.
- Error handling and safety rails: invalid rule files, unsupported Android features, and fallback behavior when document-start injection is unavailable.

### Smoke Tests Details
- `testContentBlockerConfigurationDefaults`: verifies a fresh blocker config starts empty on both iOS and Android surfaces.
- `testPopupChildMirroredConfigurationPreservesContentBlockers`: verifies popup child engines inherit the parent’s content-blocker configuration.
- `testAndroidLegacyEngineDelegateDoesNotReplaceInternalWebViewClient`: verifies the deprecated Android navigation hook no longer displaces the engine-owned blocker client.
- `testAndroidSuppliedWebViewClientIsPreservedUnderInternalClient`: verifies a caller-supplied Android `WebViewClient` is embedded under the internal blocker client instead of being dropped.
- `testAndroidPageContextDefaultsHostFromURL`: verifies Android page context derives `host` from the supplied page URL.
- `testAndroidCosmeticRuleDefaults`: verifies Android cosmetic rules default to wildcard origins, main-frame scope, and document-start timing.
- `testAndroidCosmeticRuleHiddenSelectorsConvenienceInitializer`: verifies selector-based hide rules normalize into CSS plus the expected scope/filter metadata.
- `testAndroidRedirectDetectionSkipsLookupWhenFeatureUnsupported`: verifies redirect probing is skipped when the Android WebView feature is unavailable.
- `testAndroidHistoryNavigationIndexUsesOffsetFromCurrentEntry`: verifies back/forward navigation computes the correct target history index.
- `testAndroidHistoryNavigationIndexRejectsOutOfBoundsTargets`: verifies invalid history offsets are rejected instead of pre-registering cosmetics for a bad entry.
- `testAndroidCosmeticPlanPreservesDocumentStartRuleOrder`: verifies document-start rules keep caller order when native document-start support exists.
- `testAndroidCosmeticPlanFallsBackOnlyForMainFrameRulesWhenUnsupported`: verifies unsupported document-start injection degrades only main-frame rules to lifecycle CSS.
- `testAndroidCosmeticPlanKeepsPageLifecycleRulesForMainFrameOnly`: verifies lifecycle injection keeps only rules that are valid for main-frame fallback.
- `testAndroidCosmeticPlanFiltersLifecycleRulesByAllowedOriginRules`: verifies lifecycle CSS is filtered by allowed-origin matching before injection.
- `testAndroidCosmeticPlanFiltersFallbackRulesByAllowedOriginRules`: verifies document-start fallback still respects allowed-origin filters.
- `testAndroidCosmeticPlanFiltersFallbackRulesByURLFilterPattern`: verifies document-start fallback still respects `urlFilterPattern` matching on the main document URL.
- `testAndroidRedirectFallbackPlanDegradesDocumentStartRulesEvenWhenSupported`: verifies redirected final pages intentionally degrade document-start rules to late main-frame injection.
- `testAndroidContentBlockerStyleInjectionScriptAddsMainFrameGuard`: verifies generated CSS injection scripts bail out in subframes for main-frame-only rules.
- `testAndroidContentBlockerStyleInjectionScriptAddsSubframeGuard`: verifies generated CSS injection scripts bail out in the top frame for subframe-only rules.
- `testAndroidContentBlockerStyleInjectionScriptAddsURLGuard`: verifies generated CSS injection scripts include a URL-match guard for URL-scoped rules.
- `testAndroidContentBlockerStyleInjectionScriptLeavesAllFramesUngarded`: verifies all-frame scripts omit frame guards so they can run in any frame context.
- `testAndroidContentBlockerStyleRemovalScriptTargetsInjectedStyle`: verifies stale injected blocker CSS can be removed by targeting the expected style element.
- `testIOSContentBlockerRuleListsCompileAndReusePersistentCache`: verifies iOS rule lists compile once and are reused from persistent cache on subsequent loads.
- `testIOSContentBlockersInstallIntoSuppliedWKWebView`: verifies configured iOS blocker rule lists install into a caller-supplied `WKWebView`.
- `testIOSContentBlockerRuleListChangesInvalidateCachedIdentifier`: verifies changing a rule file recompiles it and prunes the old cached identifier.
- `testIOSContentBlockerRemovingRuleFilePrunesStaleIdentifier`: verifies removing a configured rule file prunes its stale compiled rule-list entry.
- `testIOSContentBlockerSetupErrorsAreRecordedWithoutFailingConfiguration`: verifies invalid iOS rule files surface setup errors without aborting async config or engine setup.

## Quick Usage Example

```swift
struct ContentBlockingProvider: AndroidContentBlockingProvider {
    let persistentCosmeticRules: [AndroidCosmeticRule] = [
        AndroidCosmeticRule(hiddenSelectors: [".ad-banner"])
    ]

    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision {
        if request.url.host?.contains("ads") == true {
            return .block
        }
        return .allow
    }

    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule] {
        [
            AndroidCosmeticRule(
                hiddenSelectors: [".ad-slot", ".tracking-frame"],
                urlFilterPattern: ".*\\/ad-frame\\.html",
                allowedOriginRules: ["https://*.doubleclick.net"],
                ifDomainList: ["ads.example.com"],
                unlessDomainList: ["private.ads.example.com"],
                frameScope: .subframesOnly
            ),
        ]
    }
}

let configuration = WebEngineConfiguration(
    contentBlockers: WebContentBlockerConfiguration(
        iOSRuleListPaths: ["/path/to/content-blockers.json"],
        popupWhitelistedSourceDomains: ["example.com"],
        androidMode: .custom(ContentBlockingProvider())
    )
)

_ = await configuration.iOSPrepareContentBlockers()
let webViewConfiguration = await configuration.makeWebViewConfiguration()
let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
let engine = WebEngine(configuration: configuration, webView: webView)
_ = await engine.awaitContentBlockerSetup()
```

## New API Shape In This Branch

### Configuration Surface

```swift
public struct WebContentBlockerConfiguration {
    public var iOSRuleListPaths: [String]
    public var whitelistedDomains: [String]
    public var popupWhitelistedSourceDomains: [String]
    public var androidMode: AndroidContentBlockingMode

    public init(
        iOSRuleListPaths: [String] = [],
        whitelistedDomains: [String] = [],
        popupWhitelistedSourceDomains: [String] = [],
        androidMode: AndroidContentBlockingMode = .disabled
    )
}
```

`popupWhitelistedSourceDomains` is popup-only. Think of it as "allow popups from this site": a bare entry like `example.com` covers both `example.com` and common subdomains such as `www.example.com`, while `*.example.com` remains subdomains-only.

```swift
public struct WebEngineConfiguration {
    public var navigationDelegate: (any SkipWebNavigationDelegate)?
    public var contentBlockers: WebContentBlockerConfiguration?
    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]

    @MainActor public static func iOSClearContentBlockerCache() throws
    @MainActor @discardableResult public func iOSPrepareContentBlockers() async -> [WebContentBlockerError]
    @MainActor public func makeWebViewConfiguration() async -> WebViewConfiguration
}
```

```swift
public final class WebEngine {
    public private(set) var contentBlockerSetupErrors: [WebContentBlockerError]

    public func awaitContentBlockerSetup() async -> [WebContentBlockerError]
}
```

### Android Content Blocking Mode

```swift
public protocol AndroidContentBlockingProvider {
    var persistentCosmeticRules: [AndroidCosmeticRule] { get }
    func requestDecision(for request: AndroidBlockableRequest) -> AndroidRequestBlockDecision
    func navigationCosmeticRules(for page: AndroidPageContext) -> [AndroidCosmeticRule]
}
```

```swift
public enum AndroidContentBlockingMode {
    case disabled
    case custom(any AndroidContentBlockingProvider)
}
```

### Android Request Blocking

```swift
public enum AndroidRequestBlockDecision: Sendable {
    case allow
    case block
}
```

```swift
public enum AndroidResourceTypeHint: String, CaseIterable, Hashable, Sendable {
    case document
    case subdocument
    case stylesheet
    case script
    case image
    case font
    case media
    case xhr
    case fetch
    case websocket
    case other
}
```

```swift
public struct AndroidBlockableRequest: Equatable, Sendable {
    public var url: URL
    public var mainDocumentURL: URL?
    public var method: String
    public var headers: [String: String]
    public var isForMainFrame: Bool
    public var hasGesture: Bool
    public var isRedirect: Bool?
    public var resourceTypeHint: AndroidResourceTypeHint?

    public init(
        url: URL,
        mainDocumentURL: URL? = nil,
        method: String,
        headers: [String: String] = [:],
        isForMainFrame: Bool,
        hasGesture: Bool,
        isRedirect: Bool? = nil,
        resourceTypeHint: AndroidResourceTypeHint? = nil
    )
}
```

### Android Cosmetic Blocking

```swift
public struct AndroidPageContext: Equatable, Sendable {
    public var url: URL
    public var host: String?

    public init(url: URL, host: String? = nil)
}
```

```swift
public enum AndroidCosmeticFrameScope: String, CaseIterable, Hashable, Sendable {
    case mainFrameOnly
    case subframesOnly
    case allFrames
}
```

```swift
public enum AndroidCosmeticInjectionTiming: String, CaseIterable, Hashable, Sendable {
    case documentStart
    case pageLifecycle
}
```

```swift
public struct AndroidCosmeticRule: Equatable, Sendable {
    public var hiddenSelectors: [String]
    public var urlFilterPattern: String?
    public var allowedOriginRules: [String]
    public var ifDomainList: [String]
    public var unlessDomainList: [String]
    public var frameScope: AndroidCosmeticFrameScope
    public var preferredTiming: AndroidCosmeticInjectionTiming

    public init(
        hiddenSelectors: [String] = [],
        urlFilterPattern: String? = nil,
        allowedOriginRules: [String] = ["*"],
        ifDomainList: [String] = [],
        unlessDomainList: [String] = [],
        frameScope: AndroidCosmeticFrameScope = .mainFrameOnly,
        preferredTiming: AndroidCosmeticInjectionTiming = .documentStart
    )
}
```

Think of `allowedOriginRules` as the registration-time scope for Android document-start injection. `WebViewCompat.addDocumentStartJavaScript(...)` requires those origins up front. `urlFilterPattern`, `ifDomainList`, and `unlessDomainList` are the runtime frame guards checked after the script is installed, so one registered rule can stay narrow to specific frames.

### Navigation Hook

```swift
public protocol SkipWebNavigationDelegate {
    func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool
    func webEngineDidCommitNavigation(_ engine: WebEngine)
    func webEngineDidFinishNavigation(_ engine: WebEngine)
    func webEngine(_ engine: WebEngine, didFailNavigation error: Error)
}
```

Example use:

```swift
final class AppNavigationDelegate: SkipWebNavigationDelegate {
    func webEngine(_ engine: WebEngine, shouldOverrideURLLoading url: URL) -> Bool {
        if url.scheme == "mailto" || url.scheme == "myapp" {
            return true
        }
        return false
    }
}
```

### Error Reporting

```swift
public enum WebContentBlockerError: Error, Equatable, LocalizedError {
    case storeUnavailable(String)
    case fileReadFailed(path: String, description: String)
    case fileEncodingFailed(path: String)
    case cacheLookupFailed(identifier: String, description: String)
    case compilationFailed(path: String, description: String)
    case metadataReadFailed(String)
    case metadataWriteFailed(String)
    case staleRuleRemovalFailed(identifier: String, description: String)
    case operationTimedOut(String)
}
```
