### PR TITLE
JS Console capture can trigger web inspector detection and reaction on some websites

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://source.skip.tools/skip.git", from: "1.8.9"),
-        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.51.3")
+        .package(url: "https://source.skip.tools/skip-ui.git", from: "1.54.0")
     ],
     targets: [
         .target(name: "SkipWeb", dependencies: [.product(name: "SkipUI", package: "skip-ui")], resources: [.process("Resources")], plugins: [.plugin(name: "skipstone", package: "skip")]),
@@ -21,7 +21,7 @@ let package = Package(
 if Context.environment["SKIP_BRIDGE"] ?? "0" != "0" {
     package.dependencies += [
         .package(url: "https://source.skip.tools/skip-bridge.git", "0.0.0"..<"2.0.0"),
-        .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.14.5")
+        .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.15.2")
     ]
     package.targets.forEach({ target in
         target.dependencies += [

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The package currently targets Apple platforms starting at iOS 17, macOS 14, tvOS
 Current package dependencies are:
 
 - `skip` from `1.8.9`
-- `skip-ui` from `1.51.3`
-- when `SKIP_BRIDGE` is enabled, `skip-bridge` in `0.0.0..<2.0.0` and `skip-fuse-ui` from `1.14.5`
+- `skip-ui` from `1.54.0`
+- when `SKIP_BRIDGE` is enabled, `skip-bridge` in `0.0.0..<2.0.0` and `skip-fuse-ui` from `1.15.2`
 
 ## WebView: Customizable Embedded Web Browser
 

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -2814,7 +2814,8 @@ extension WebCookie {
     @MainActor
     public func refreshMessageHandlers() {
         let userContentController = webView.configuration.userContentController
-        for messageHandlerName in Self.systemMessageHandlers + Array(configuration.allRegisteredMessageHandlerNames) {
+        let systemMessageHandlers = configuration.capturesConsoleOutput ? Self.systemMessageHandlers : []
+        for messageHandlerName in systemMessageHandlers + Array(configuration.allRegisteredMessageHandlerNames) {
             if registeredMessageHandlerNames.contains(messageHandlerName) { continue }
 
             // Sometimes we reuse an underlying WKWebView for a new SwiftUI component.
@@ -2822,7 +2823,7 @@ extension WebCookie {
             userContentController.add(self, contentWorld: .page, name: messageHandlerName)
             registeredMessageHandlerNames.insert(messageHandlerName)
         }
-        for missing in registeredMessageHandlerNames.subtracting(Set(Self.systemMessageHandlers).union(configuration.allRegisteredMessageHandlerNames)) {
+        for missing in registeredMessageHandlerNames.subtracting(Set(systemMessageHandlers).union(configuration.allRegisteredMessageHandlerNames)) {
             userContentController.removeScriptMessageHandler(forName: missing)
             registeredMessageHandlerNames.remove(missing)
         }
@@ -2831,7 +2832,8 @@ extension WebCookie {
     @MainActor
     public func updateUserScripts() {
         let userContentController = webView.configuration.userContentController
-        let allScripts = WebViewUserScript.systemScripts + configuration.userScripts
+        let systemScripts = configuration.capturesConsoleOutput ? WebViewUserScript.systemScripts : []
+        let allScripts = systemScripts + configuration.userScripts
         if userContentController.userScripts.sorted(by: { $0.source > $1.source }) != allScripts.map({ $0.webKitUserScript }).sorted(by: { $0.source > $1.source }) {
             userContentController.removeAllUserScripts()
             for script in allScripts {
@@ -4042,6 +4044,8 @@ public extension SkipWebUIDelegate {
     public var navigationDelegate: (any SkipWebNavigationDelegate)?
     /// Optional content-blocker configuration applied to web views created from this configuration.
     public var contentBlockers: WebContentBlockerConfiguration?
+    /// Enables the built-in page-world console bridge that forwards page `console.*` calls to native logs.
+    public var capturesConsoleOutput: Bool
     /// The latest errors produced while preparing or installing content blockers.
     public private(set) var contentBlockerSetupErrors: [WebContentBlockerError] = []
 
@@ -4076,7 +4080,8 @@ public extension SkipWebUIDelegate {
                 schemeHandlers: [String: URLSchemeHandler] = [:],
                 uiDelegate: (any SkipWebUIDelegate)? = nil,
                 navigationDelegate: (any SkipWebNavigationDelegate)? = nil,
-                contentBlockers: WebContentBlockerConfiguration? = nil) {
+                contentBlockers: WebContentBlockerConfiguration? = nil,
+                capturesConsoleOutput: Bool = true) {
         self.javaScriptEnabled = javaScriptEnabled
         self.javaScriptCanOpenWindowsAutomatically = javaScriptCanOpenWindowsAutomatically
         self.allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures
@@ -4096,6 +4101,7 @@ public extension SkipWebUIDelegate {
         self.uiDelegate = uiDelegate
         self.navigationDelegate = navigationDelegate
         self.contentBlockers = contentBlockers
+        self.capturesConsoleOutput = capturesConsoleOutput
     }
 
     var scriptMessageHandlerNameSet: Set<String> {
@@ -4126,7 +4132,8 @@ public extension SkipWebUIDelegate {
             schemeHandlers: schemeHandlers,
             uiDelegate: uiDelegate,
             navigationDelegate: navigationDelegate,
-            contentBlockers: contentBlockers
+            contentBlockers: contentBlockers,
+            capturesConsoleOutput: capturesConsoleOutput
         )
         #if SKIP
         copy.context = context

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -711,6 +711,9 @@ extension WebView : ViewRepresentable {
                 let webEngine = setupWebView(resolvedWebEngine, coordinator: coordinator)
                 navigator.webEngine = webEngine
                 let view = webEngine.webView
+                if let parent = view.parent as? ViewGroup {
+                    parent.removeView(view)
+                }
                 // AndroidView does not reliably push the parent's fill constraints into the
                 // embedded WebView on the first layout pass, so we request fill sizing from both
                 // Compose and the native view to avoid a zero-height viewport.
@@ -1612,7 +1615,7 @@ extension WebViewCoordinator: WebNavigationDelegate {
         guard let url = navigationAction.request.url else {
             return (.allow, preferences)
         }
-        
+
         if (self.webView.shouldOverrideUrlLoading?(url) ?? false) {
             logger.log("Override URL loading for \(url)")
             self.webView.state.isProvisionallyNavigating = false

--- a/Tests/SkipWebTests/SkipWebTests.swift
+++ b/Tests/SkipWebTests/SkipWebTests.swift
@@ -81,12 +81,19 @@ final class SkipWebTests: XCTestCase {
         XCTAssertFalse(config.javaScriptCanOpenWindowsAutomatically)
         XCTAssertNil(config.uiDelegate)
         XCTAssertEqual(config.profile, WebProfile.default)
+        XCTAssertTrue(config.capturesConsoleOutput)
     }
 
     func testPopupChildMirroredConfigurationPreservesProfile() {
         let config = WebEngineConfiguration(profile: .named("popup-profile"))
         let mirrored = config.popupChildMirroredConfiguration()
         XCTAssertEqual(mirrored.profile, .named("popup-profile"))
+    }
+
+    func testPopupChildMirroredConfigurationPreservesConsoleCapture() {
+        let config = WebEngineConfiguration(capturesConsoleOutput: false)
+        let mirrored = config.popupChildMirroredConfiguration()
+        XCTAssertFalse(mirrored.capturesConsoleOutput)
     }
 
     func testWebWindowRequestCarriesFields() throws {


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex generated the code, visually confirmed by testing from a sandbox app

-----

Context: some websites have defensive mechanisms in place to make web pages unusable when webtools are detected (web inspector etc...). For example the website will automatically redirect to the homepage to prevent inspection on their web pages

This PR makes console capture configurable with `WebEngineConfiguration.capturesConsoleOutput`. `capturesConsoleOutput`  defaults to `true` for backward compatibility (if not for backward compatibility I think it would make sense to be defensive and make it an opt-in feature instead given the unexpected behavior on affected websites)