### PR TITLE
Snapshot performance optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,11 +613,13 @@ let snapshot = try await navigator.takeSnapshot(
     configuration: SkipWebSnapshotConfiguration(
         rect: .null,
         snapshotWidth: 240,
-        afterScreenUpdates: true
+        afterScreenUpdates: true,
+        imageFormat: .jpeg(quality: 0.85)
     )
 )
 
-let png = snapshot.pngData
+let imageData = snapshot.imageData
+let mimeType = snapshot.imageFormat.mimeType
 ```
 
 On Android, `afterScreenUpdates` is best-effort: SkipWeb captures on the next UI tick before drawing the `WebView` into a bitmap.

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ using `SkipWebSnapshotConfiguration`, which mirrors the core `WKSnapshotConfigur
 - `rect` (`.null` captures the full visible web view bounds)
 - `snapshotWidth` (output width while preserving aspect ratio)
 - `afterScreenUpdates`
+- `imageFormat` (`.jpeg(quality: 0.85)` by default, or `.png`)
 
 ```swift
 let snapshot = try await navigator.takeSnapshot(
@@ -622,7 +623,7 @@ let imageData = snapshot.imageData
 let mimeType = snapshot.imageFormat.mimeType
 ```
 
-On Android, `afterScreenUpdates` is best-effort: SkipWeb captures on the next UI tick before drawing the `WebView` into a bitmap.
+On Android, `afterScreenUpdates` is best-effort: SkipWeb captures on the next UI tick, then uses `PixelCopy` when the `WebView` is attached and visible, falling back to drawing the `WebView` into a bitmap when `PixelCopy` is unavailable.
 If that UI-tick wait cannot be scheduled (for example, when the view is detached), `takeSnapshot` throws `WebSnapshotError.afterScreenUpdatesUnavailable`.
 
 ### Link Context Menu (long-press)

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ using `SkipWebSnapshotConfiguration`, which mirrors the core `WKSnapshotConfigur
 - `rect` (`.null` captures the full visible web view bounds)
 - `snapshotWidth` (output width while preserving aspect ratio)
 - `afterScreenUpdates`
+- `androidCaptureMode` (`.webViewContent` by default, or `.visibleWindowPixels`)
 - `imageFormat` (`.jpeg(quality: 0.85)` by default, or `.png`)
 
 ```swift
@@ -615,6 +616,7 @@ let snapshot = try await navigator.takeSnapshot(
         rect: .null,
         snapshotWidth: 240,
         afterScreenUpdates: true,
+        androidCaptureMode: .webViewContent,
         imageFormat: .jpeg(quality: 0.85)
     )
 )
@@ -623,8 +625,16 @@ let imageData = snapshot.imageData
 let mimeType = snapshot.imageFormat.mimeType
 ```
 
-On Android, `afterScreenUpdates` is best-effort: SkipWeb captures on the next UI tick, then uses `PixelCopy` when the `WebView` is attached and visible, falling back to drawing the `WebView` into a bitmap when `PixelCopy` is unavailable.
-If that UI-tick wait cannot be scheduled (for example, when the view is detached), `takeSnapshot` throws `WebSnapshotError.afterScreenUpdatesUnavailable`.
+On Android, capture timing and capture source are independent:
+
+| Mode | Captures |
+| --- | --- |
+| `.webViewContent` | The WebView's rendered content, using `WebView.draw(Canvas)`. The capture compensates for the current scroll offset and excludes other window content, including overlays and blur effects. Some video, surface, or other compositor-backed content may not appear. |
+| `.visibleWindowPixels` | The final pixels currently composited inside the WebView's window rectangle, using `PixelCopy`. This includes WebView content and anything drawn over it, including overlays and blur effects. |
+
+`afterScreenUpdates` waits for the next UI tick before either capture mode. If the wait cannot be scheduled, `takeSnapshot` throws `WebSnapshotError.afterScreenUpdatesUnavailable`.
+
+SkipWeb does not switch between these modes automatically. `.visibleWindowPixels` requires the WebView to be attached to a valid window. If PixelCopy is unavailable or fails, `takeSnapshot` throws `WebSnapshotError.visibleWindowPixelsCaptureFailed`.
 
 ### Link Context Menu (long-press)
 

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -173,32 +173,83 @@ public struct SkipWebSnapshotRect: Equatable, Sendable {
     }
 }
 
+/// Bridge-safe encoded image format for a web-view snapshot.
+public struct SkipWebSnapshotImageFormat: Equatable, Sendable {
+    /// PNG snapshot encoding.
+    public static let png = SkipWebSnapshotImageFormat(mimeType: "image/png", quality: 1.0)
+
+    /// JPEG snapshot encoding with a clamped quality in the `0.0...1.0` range.
+    public static func jpeg(quality: Double = 0.85) -> SkipWebSnapshotImageFormat {
+        SkipWebSnapshotImageFormat(mimeType: "image/jpeg", quality: quality)
+    }
+
+    /// MIME type for the encoded snapshot image data.
+    public let mimeType: String
+    /// Encoding quality clamped to the `0.0...1.0` range.
+    public let quality: Double
+
+    /// Creates an image format from bridge-safe stored values.
+    ///
+    /// Only JPEG and PNG are currently supported. Unknown MIME types are normalized to JPEG.
+    public init(mimeType: String, quality: Double = 0.85) {
+        if mimeType == "image/png" {
+            self.mimeType = "image/png"
+            self.quality = 1.0
+        } else {
+            self.mimeType = "image/jpeg"
+            self.quality = min(max(quality, 0.0), 1.0)
+        }
+    }
+
+    fileprivate var isPNG: Bool {
+        mimeType == "image/png"
+    }
+}
+
 /// Snapshot configuration for `WebEngine.takeSnapshot(configuration:)`.
 ///
 /// This mirrors the key behavior of `WKSnapshotConfiguration`:
 /// - `rect`: view-coordinate capture region (`.null` means full visible bounds)
 /// - `snapshotWidth`: optional output width while preserving aspect ratio
 /// - `afterScreenUpdates`: capture after pending updates when possible
+/// - `imageFormat`: encoded output format for the returned image bytes
 public struct SkipWebSnapshotConfiguration: Sendable {
+    /// View-coordinate capture region (`.null` means full visible bounds).
     public var rect: SkipWebSnapshotRect
+    /// Optional output width while preserving aspect ratio.
     public var snapshotWidth: Double?
+    /// Capture after pending updates when possible.
     public var afterScreenUpdates: Bool
+    /// Encoded output format for the returned image bytes.
+    public var imageFormat: SkipWebSnapshotImageFormat
 
-    public init(rect: SkipWebSnapshotRect = .null, snapshotWidth: Double? = nil, afterScreenUpdates: Bool = true) {
+    public init(
+        rect: SkipWebSnapshotRect = .null,
+        snapshotWidth: Double? = nil,
+        afterScreenUpdates: Bool = true,
+        imageFormat: SkipWebSnapshotImageFormat = .jpeg(quality: 0.85)
+    ) {
         self.rect = rect
         self.snapshotWidth = snapshotWidth
         self.afterScreenUpdates = afterScreenUpdates
+        self.imageFormat = imageFormat
     }
 }
 
-/// A captured web-view snapshot stored as PNG bytes plus pixel dimensions.
+/// A captured web-view snapshot stored as encoded image bytes plus metadata.
 public struct SkipWebSnapshot: Sendable {
-    public let pngData: Data
+    /// Encoded image bytes for this snapshot.
+    public let imageData: Data
+    /// Format used to encode `imageData`.
+    public let imageFormat: SkipWebSnapshotImageFormat
+    /// Encoded image width in pixels.
     public let pixelWidth: Int
+    /// Encoded image height in pixels.
     public let pixelHeight: Int
 
-    public init(pngData: Data, pixelWidth: Int, pixelHeight: Int) {
-        self.pngData = pngData
+    public init(imageData: Data, imageFormat: SkipWebSnapshotImageFormat, pixelWidth: Int, pixelHeight: Int) {
+        self.imageData = imageData
+        self.imageFormat = imageFormat
         self.pixelWidth = pixelWidth
         self.pixelHeight = pixelHeight
     }
@@ -209,7 +260,7 @@ public enum WebSnapshotError: Error {
     case afterScreenUpdatesUnavailable
     case invalidRect
     case emptySnapshot
-    case pngEncodingFailed
+    case imageEncodingFailed
 }
 
 /// Portable cookie representation shared by iOS and Android implementations.
@@ -1799,26 +1850,37 @@ extension WebCookie {
         platformConfig.afterScreenUpdates = config.afterScreenUpdates
 
         let snapshotImage = try await webView.takeSnapshot(configuration: platformConfig)
-        guard let pngData = snapshotImage.pngData() else {
-            throw WebSnapshotError.pngEncodingFailed
+        let imageData: Data?
+        if config.imageFormat.isPNG {
+            imageData = snapshotImage.pngData()
+        } else {
+            imageData = snapshotImage.jpegData(compressionQuality: config.imageFormat.quality)
+        }
+        guard let imageData else {
+            throw WebSnapshotError.imageEncodingFailed
         }
 
         let pixelWidth = Int(snapshotImage.size.width * snapshotImage.scale)
         let pixelHeight = Int(snapshotImage.size.height * snapshotImage.scale)
         return SkipWebSnapshot(
-            pngData: pngData,
+            imageData: imageData,
+            imageFormat: config.imageFormat,
             pixelWidth: pixelWidth,
             pixelHeight: pixelHeight
         )
         #else
+        let snapshotProbeMarker = "2026-06-12-local-snapshot-optimization-v4-wrapper-timing"
+        let snapshotStartedAt = java.lang.System.currentTimeMillis()
         let sourceWidth = Int(webView.getWidth())
         let sourceHeight = Int(webView.getHeight())
-        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v1 phase=start sourceWidth=\(sourceWidth) sourceHeight=\(sourceHeight)")
+        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=start sourceWidth=\(sourceWidth) sourceHeight=\(sourceHeight) afterScreenUpdates=\(config.afterScreenUpdates)")
         guard sourceWidth > 0, sourceHeight > 0 else {
             throw WebSnapshotError.viewNotLaidOut
         }
 
+        var afterScreenUpdatesWaitElapsedMs = -1
         if config.afterScreenUpdates {
+            let afterScreenUpdatesWaitStartedAt = java.lang.System.currentTimeMillis()
             let didScheduleUIUpdateWait: Bool = suspendCancellableCoroutine { continuation in
                 let scheduled = webView.post {
                     continuation.resume(true)
@@ -1831,6 +1893,7 @@ extension WebCookie {
                     continuation.cancel()
                 }
             }
+            afterScreenUpdatesWaitElapsedMs = Int(java.lang.System.currentTimeMillis() - afterScreenUpdatesWaitStartedAt)
             guard didScheduleUIUpdateWait else {
                 throw WebSnapshotError.afterScreenUpdatesUnavailable
             }
@@ -1861,6 +1924,66 @@ extension WebCookie {
         let targetHeight = max(1, Int((Double(captureHeight) * (Double(targetWidth) / Double(captureWidth))).rounded()))
 
         let bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
+        let captureStartedAt = java.lang.System.currentTimeMillis()
+        let didUsePixelCopy = await copyAndroidSnapshotWithPixelCopyIfAvailable(
+            into: bitmap,
+            minX: minX,
+            minY: minY,
+            maxX: maxX,
+            maxY: maxY,
+            afterScreenUpdates: config.afterScreenUpdates,
+            marker: snapshotProbeMarker
+        )
+        if !didUsePixelCopy {
+            drawAndroidSnapshot(
+                into: bitmap,
+                minX: minX,
+                minY: minY,
+                captureWidth: captureWidth,
+                captureHeight: captureHeight,
+                targetWidth: targetWidth,
+                targetHeight: targetHeight
+            )
+        }
+        let captureFinishedAt = java.lang.System.currentTimeMillis()
+        let capturePath = didUsePixelCopy ? "pixelCopy" : "drawFallback"
+        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=captured path=\(capturePath) targetWidth=\(targetWidth) targetHeight=\(targetHeight) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality) captureElapsedMs=\(captureFinishedAt - captureStartedAt) totalElapsedMs=\(captureFinishedAt - snapshotStartedAt)")
+
+        let outputStream = java.io.ByteArrayOutputStream()
+        let encodeStartedAt = java.lang.System.currentTimeMillis()
+        let compressFormat = config.imageFormat.isPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG
+        let compressionQuality = config.imageFormat.isPNG ? 100 : min(max(Int((config.imageFormat.quality * 100.0).rounded()), 0), 100)
+        let encoded = bitmap.compress(compressFormat, compressionQuality, outputStream)
+        let encodeFinishedAt = java.lang.System.currentTimeMillis()
+        bitmap.recycle()
+        guard encoded else {
+            throw WebSnapshotError.imageEncodingFailed
+        }
+
+        let dataStartedAt = java.lang.System.currentTimeMillis()
+        let imageData = Data(platformValue: outputStream.toByteArray())
+        let dataFinishedAt = java.lang.System.currentTimeMillis()
+        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=encoded path=\(capturePath) targetWidth=\(targetWidth) targetHeight=\(targetHeight) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality) bytes=\(imageData.count) encodeElapsedMs=\(encodeFinishedAt - encodeStartedAt) dataElapsedMs=\(dataFinishedAt - dataStartedAt) totalElapsedMs=\(dataFinishedAt - snapshotStartedAt)")
+        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=timing path=\(capturePath) waitElapsedMs=\(afterScreenUpdatesWaitElapsedMs) setupElapsedMs=\(captureStartedAt - snapshotStartedAt) captureElapsedMs=\(captureFinishedAt - captureStartedAt) encodeElapsedMs=\(encodeFinishedAt - encodeStartedAt) dataElapsedMs=\(dataFinishedAt - dataStartedAt) totalElapsedMs=\(dataFinishedAt - snapshotStartedAt) bytes=\(imageData.count) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality)")
+        return SkipWebSnapshot(
+            imageData: imageData,
+            imageFormat: config.imageFormat,
+            pixelWidth: targetWidth,
+            pixelHeight: targetHeight
+        )
+        #endif
+    }
+
+    #if SKIP
+    private func drawAndroidSnapshot(
+        into bitmap: Bitmap,
+        minX: Int,
+        minY: Int,
+        captureWidth: Int,
+        captureHeight: Int,
+        targetWidth: Int,
+        targetHeight: Int
+    ) {
         let canvas = Canvas(bitmap)
         let scaleX = Float(Double(targetWidth) / Double(captureWidth))
         let scaleY = Float(Double(targetHeight) / Double(captureHeight))
@@ -1871,23 +1994,98 @@ extension WebCookie {
         // so we must compensate or the snapshot is padded by blank space.
         canvas.translate(-Float(minX + scrollX), -Float(minY + scrollY))
         webView.draw(canvas)
+    }
 
-        let outputStream = java.io.ByteArrayOutputStream()
-        let encoded = bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-        bitmap.recycle()
-        guard encoded else {
-            throw WebSnapshotError.pngEncodingFailed
+    private func copyAndroidSnapshotWithPixelCopyIfAvailable(
+        into bitmap: Bitmap,
+        minX: Int,
+        minY: Int,
+        maxX: Int,
+        maxY: Int,
+        afterScreenUpdates: Bool,
+        marker: String
+    ) async -> Bool {
+        guard afterScreenUpdates else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=afterScreenUpdatesFalse")
+            return false
+        }
+        guard false else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=pixelCopyTemporarilyDisabled")
+            return false
+        }
+        guard android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=apiTooOld sdk=\(android.os.Build.VERSION.SDK_INT)")
+            return false
+        }
+        guard webView.isAttachedToWindow() else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=webViewDetached")
+            return false
+        }
+        guard webView.getWindowToken() != nil else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingWindowToken")
+            return false
+        }
+        guard let activity = Self.androidActivity(from: webView.getContext()) else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingActivityContext")
+            return false
+        }
+        guard activity.window.peekDecorView() != nil else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingDecorView")
+            return false
         }
 
-        let pngData = Data(platformValue: outputStream.toByteArray())
-        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v1 phase=encoded targetWidth=\(targetWidth) targetHeight=\(targetHeight) bytes=\(pngData.count)")
-        return SkipWebSnapshot(
-            pngData: pngData,
-            pixelWidth: targetWidth,
-            pixelHeight: targetHeight
+        let localVisibleRect = android.graphics.Rect()
+        if webView.getLocalVisibleRect(localVisibleRect) {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision visibleDiagnostic requestedLeft=\(minX) requestedTop=\(minY) requestedRight=\(maxX) requestedBottom=\(maxY) visibleLeft=\(localVisibleRect.left) visibleTop=\(localVisibleRect.top) visibleRight=\(localVisibleRect.right) visibleBottom=\(localVisibleRect.bottom)")
+        } else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision visibleDiagnostic reason=notLocallyVisible")
+        }
+
+        let locationInWindow = IntArray(2)
+        webView.getLocationInWindow(locationInWindow)
+        let sourceRect = android.graphics.Rect(
+            locationInWindow[0] + minX,
+            locationInWindow[1] + minY,
+            locationInWindow[0] + maxX,
+            locationInWindow[1] + maxY
         )
-        #endif
+        guard sourceRect.width() > 0, sourceRect.height() > 0 else {
+            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=emptyWindowSourceRect sourceLeft=\(sourceRect.left) sourceTop=\(sourceRect.top) sourceRight=\(sourceRect.right) sourceBottom=\(sourceRect.bottom)")
+            return false
+        }
+        logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=true reason=eligible sourceLeft=\(sourceRect.left) sourceTop=\(sourceRect.top) sourceRight=\(sourceRect.right) sourceBottom=\(sourceRect.bottom)")
+
+        return suspendCancellableCoroutine { continuation in
+            let handler = android.os.Handler(android.os.Looper.getMainLooper())
+            // SKIP INSERT: try {
+            android.view.PixelCopy.request(activity.window, sourceRect, bitmap, { result in
+                logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyResult result=\(result) success=\(result == android.view.PixelCopy.SUCCESS)")
+                continuation.resume(result == android.view.PixelCopy.SUCCESS)
+            }, handler)
+            // SKIP INSERT: } catch (t: Throwable) {
+            // SKIP INSERT:     logger.info("[skip-web-snapshot-probe] marker=${marker} phase=pixelCopyDecision selected=false reason=requestException error=${t.message ?: t}")
+            // SKIP INSERT:     continuation.resume(false)
+            // SKIP INSERT: }
+            continuation.invokeOnCancellation { _ in
+                continuation.cancel()
+            }
+        }
     }
+
+    private static func androidActivity(from context: android.content.Context?) -> android.app.Activity? {
+        var currentContext = context
+        while currentContext != nil {
+            if let activity = currentContext as? android.app.Activity {
+                return activity
+            } else if let wrapper = currentContext as? android.content.ContextWrapper {
+                currentContext = wrapper.baseContext
+            } else {
+                break
+            }
+        }
+        return nil
+    }
+    #endif
 
     public func loadHTML(_ html: String, baseURL: URL? = nil, mimeType: String = "text/html") {
         if profileSetupError != nil {

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -1869,18 +1869,13 @@ extension WebCookie {
             pixelHeight: pixelHeight
         )
         #else
-        let snapshotProbeMarker = "2026-06-12-local-snapshot-optimization-v4-wrapper-timing"
-        let snapshotStartedAt = java.lang.System.currentTimeMillis()
         let sourceWidth = Int(webView.getWidth())
         let sourceHeight = Int(webView.getHeight())
-        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=start sourceWidth=\(sourceWidth) sourceHeight=\(sourceHeight) afterScreenUpdates=\(config.afterScreenUpdates)")
         guard sourceWidth > 0, sourceHeight > 0 else {
             throw WebSnapshotError.viewNotLaidOut
         }
 
-        var afterScreenUpdatesWaitElapsedMs = -1
         if config.afterScreenUpdates {
-            let afterScreenUpdatesWaitStartedAt = java.lang.System.currentTimeMillis()
             let didScheduleUIUpdateWait: Bool = suspendCancellableCoroutine { continuation in
                 let scheduled = webView.post {
                     continuation.resume(true)
@@ -1893,7 +1888,6 @@ extension WebCookie {
                     continuation.cancel()
                 }
             }
-            afterScreenUpdatesWaitElapsedMs = Int(java.lang.System.currentTimeMillis() - afterScreenUpdatesWaitStartedAt)
             guard didScheduleUIUpdateWait else {
                 throw WebSnapshotError.afterScreenUpdatesUnavailable
             }
@@ -1924,15 +1918,13 @@ extension WebCookie {
         let targetHeight = max(1, Int((Double(captureHeight) * (Double(targetWidth) / Double(captureWidth))).rounded()))
 
         let bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
-        let captureStartedAt = java.lang.System.currentTimeMillis()
         let didUsePixelCopy = await copyAndroidSnapshotWithPixelCopyIfAvailable(
             into: bitmap,
             minX: minX,
             minY: minY,
             maxX: maxX,
             maxY: maxY,
-            afterScreenUpdates: config.afterScreenUpdates,
-            marker: snapshotProbeMarker
+            afterScreenUpdates: config.afterScreenUpdates
         )
         if !didUsePixelCopy {
             drawAndroidSnapshot(
@@ -1945,26 +1937,17 @@ extension WebCookie {
                 targetHeight: targetHeight
             )
         }
-        let captureFinishedAt = java.lang.System.currentTimeMillis()
-        let capturePath = didUsePixelCopy ? "pixelCopy" : "drawFallback"
-        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=captured path=\(capturePath) targetWidth=\(targetWidth) targetHeight=\(targetHeight) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality) captureElapsedMs=\(captureFinishedAt - captureStartedAt) totalElapsedMs=\(captureFinishedAt - snapshotStartedAt)")
 
         let outputStream = java.io.ByteArrayOutputStream()
-        let encodeStartedAt = java.lang.System.currentTimeMillis()
         let compressFormat = config.imageFormat.isPNG ? Bitmap.CompressFormat.PNG : Bitmap.CompressFormat.JPEG
         let compressionQuality = config.imageFormat.isPNG ? 100 : min(max(Int((config.imageFormat.quality * 100.0).rounded()), 0), 100)
         let encoded = bitmap.compress(compressFormat, compressionQuality, outputStream)
-        let encodeFinishedAt = java.lang.System.currentTimeMillis()
         bitmap.recycle()
         guard encoded else {
             throw WebSnapshotError.imageEncodingFailed
         }
 
-        let dataStartedAt = java.lang.System.currentTimeMillis()
         let imageData = Data(platformValue: outputStream.toByteArray())
-        let dataFinishedAt = java.lang.System.currentTimeMillis()
-        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=encoded path=\(capturePath) targetWidth=\(targetWidth) targetHeight=\(targetHeight) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality) bytes=\(imageData.count) encodeElapsedMs=\(encodeFinishedAt - encodeStartedAt) dataElapsedMs=\(dataFinishedAt - dataStartedAt) totalElapsedMs=\(dataFinishedAt - snapshotStartedAt)")
-        logger.info("[skip-web-snapshot-probe] marker=\(snapshotProbeMarker) phase=timing path=\(capturePath) waitElapsedMs=\(afterScreenUpdatesWaitElapsedMs) setupElapsedMs=\(captureStartedAt - snapshotStartedAt) captureElapsedMs=\(captureFinishedAt - captureStartedAt) encodeElapsedMs=\(encodeFinishedAt - encodeStartedAt) dataElapsedMs=\(dataFinishedAt - dataStartedAt) totalElapsedMs=\(dataFinishedAt - snapshotStartedAt) bytes=\(imageData.count) format=\(config.imageFormat.mimeType) quality=\(config.imageFormat.quality)")
         return SkipWebSnapshot(
             imageData: imageData,
             imageFormat: config.imageFormat,
@@ -2002,43 +1985,25 @@ extension WebCookie {
         minY: Int,
         maxX: Int,
         maxY: Int,
-        afterScreenUpdates: Bool,
-        marker: String
+        afterScreenUpdates: Bool
     ) async -> Bool {
         guard afterScreenUpdates else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=afterScreenUpdatesFalse")
-            return false
-        }
-        guard false else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=pixelCopyTemporarilyDisabled")
             return false
         }
         guard android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=apiTooOld sdk=\(android.os.Build.VERSION.SDK_INT)")
             return false
         }
         guard webView.isAttachedToWindow() else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=webViewDetached")
             return false
         }
         guard webView.getWindowToken() != nil else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingWindowToken")
             return false
         }
         guard let activity = Self.androidActivity(from: webView.getContext()) else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingActivityContext")
             return false
         }
         guard activity.window.peekDecorView() != nil else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=missingDecorView")
             return false
-        }
-
-        let localVisibleRect = android.graphics.Rect()
-        if webView.getLocalVisibleRect(localVisibleRect) {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision visibleDiagnostic requestedLeft=\(minX) requestedTop=\(minY) requestedRight=\(maxX) requestedBottom=\(maxY) visibleLeft=\(localVisibleRect.left) visibleTop=\(localVisibleRect.top) visibleRight=\(localVisibleRect.right) visibleBottom=\(localVisibleRect.bottom)")
-        } else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision visibleDiagnostic reason=notLocallyVisible")
         }
 
         let locationInWindow = IntArray(2)
@@ -2050,20 +2015,16 @@ extension WebCookie {
             locationInWindow[1] + maxY
         )
         guard sourceRect.width() > 0, sourceRect.height() > 0 else {
-            logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=false reason=emptyWindowSourceRect sourceLeft=\(sourceRect.left) sourceTop=\(sourceRect.top) sourceRight=\(sourceRect.right) sourceBottom=\(sourceRect.bottom)")
             return false
         }
-        logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyDecision selected=true reason=eligible sourceLeft=\(sourceRect.left) sourceTop=\(sourceRect.top) sourceRight=\(sourceRect.right) sourceBottom=\(sourceRect.bottom)")
 
         return suspendCancellableCoroutine { continuation in
             let handler = android.os.Handler(android.os.Looper.getMainLooper())
             // SKIP INSERT: try {
             android.view.PixelCopy.request(activity.window, sourceRect, bitmap, { result in
-                logger.info("[skip-web-snapshot-probe] marker=\(marker) phase=pixelCopyResult result=\(result) success=\(result == android.view.PixelCopy.SUCCESS)")
                 continuation.resume(result == android.view.PixelCopy.SUCCESS)
             }, handler)
             // SKIP INSERT: } catch (t: Throwable) {
-            // SKIP INSERT:     logger.info("[skip-web-snapshot-probe] marker=${marker} phase=pixelCopyDecision selected=false reason=requestException error=${t.message ?: t}")
             // SKIP INSERT:     continuation.resume(false)
             // SKIP INSERT: }
             continuation.invokeOnCancellation { _ in

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -1813,6 +1813,7 @@ extension WebCookie {
         #else
         let sourceWidth = Int(webView.getWidth())
         let sourceHeight = Int(webView.getHeight())
+        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v1 phase=start sourceWidth=\(sourceWidth) sourceHeight=\(sourceHeight)")
         guard sourceWidth > 0, sourceHeight > 0 else {
             throw WebSnapshotError.viewNotLaidOut
         }
@@ -1878,10 +1879,8 @@ extension WebCookie {
             throw WebSnapshotError.pngEncodingFailed
         }
 
-        let base64 = android.util.Base64.encodeToString(outputStream.toByteArray(), android.util.Base64.NO_WRAP)
-        guard let pngData: Data = Data(base64Encoded: base64, options: []) else {
-            throw WebSnapshotError.pngEncodingFailed
-        }
+        let pngData = Data(platformValue: outputStream.toByteArray())
+        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v1 phase=encoded targetWidth=\(targetWidth) targetHeight=\(targetHeight) bytes=\(pngData.count)")
         return SkipWebSnapshot(
             pngData: pngData,
             pixelWidth: targetWidth,

--- a/Sources/SkipWeb/WebEngine.swift
+++ b/Sources/SkipWeb/WebEngine.swift
@@ -206,6 +206,19 @@ public struct SkipWebSnapshotImageFormat: Equatable, Sendable {
     }
 }
 
+/// Selects the Android rendering source used to capture a web-view snapshot.
+public enum AndroidSnapshotCaptureMode: Hashable, Sendable {
+    /// Draws the WebView content directly into a bitmap-backed canvas.
+    ///
+    /// This excludes other window content, including overlays and blur effects, and compensates
+    /// for the WebView's current scroll offset so the visible portion of the page is captured.
+    case webViewContent
+    /// Copies the pixels currently composited in the WebView's window rectangle.
+    ///
+    /// This includes anything drawn over the WebView, including overlays and blur effects.
+    case visibleWindowPixels
+}
+
 /// Snapshot configuration for `WebEngine.takeSnapshot(configuration:)`.
 ///
 /// This mirrors the key behavior of `WKSnapshotConfiguration`:
@@ -213,6 +226,9 @@ public struct SkipWebSnapshotImageFormat: Equatable, Sendable {
 /// - `snapshotWidth`: optional output width while preserving aspect ratio
 /// - `afterScreenUpdates`: capture after pending updates when possible
 /// - `imageFormat`: encoded output format for the returned image bytes
+///
+/// On Android, `androidCaptureMode` selects whether the WebView content or its composited window
+/// pixels are captured. It has no effect on iOS.
 public struct SkipWebSnapshotConfiguration: Sendable {
     /// View-coordinate capture region (`.null` means full visible bounds).
     public var rect: SkipWebSnapshotRect
@@ -220,6 +236,8 @@ public struct SkipWebSnapshotConfiguration: Sendable {
     public var snapshotWidth: Double?
     /// Capture after pending updates when possible.
     public var afterScreenUpdates: Bool
+    /// Rendering source used for Android snapshots. This value has no effect on iOS.
+    public var androidCaptureMode: AndroidSnapshotCaptureMode
     /// Encoded output format for the returned image bytes.
     public var imageFormat: SkipWebSnapshotImageFormat
 
@@ -227,11 +245,13 @@ public struct SkipWebSnapshotConfiguration: Sendable {
         rect: SkipWebSnapshotRect = .null,
         snapshotWidth: Double? = nil,
         afterScreenUpdates: Bool = true,
+        androidCaptureMode: AndroidSnapshotCaptureMode = .webViewContent,
         imageFormat: SkipWebSnapshotImageFormat = .jpeg(quality: 0.85)
     ) {
         self.rect = rect
         self.snapshotWidth = snapshotWidth
         self.afterScreenUpdates = afterScreenUpdates
+        self.androidCaptureMode = androidCaptureMode
         self.imageFormat = imageFormat
     }
 }
@@ -261,6 +281,8 @@ public enum WebSnapshotError: Error {
     case invalidRect
     case emptySnapshot
     case imageEncodingFailed
+    /// PixelCopy could not capture the requested visible window pixels on Android.
+    case visibleWindowPixelsCaptureFailed
 }
 
 /// Portable cookie representation shared by iOS and Android implementations.
@@ -1918,15 +1940,7 @@ extension WebCookie {
         let targetHeight = max(1, Int((Double(captureHeight) * (Double(targetWidth) / Double(captureWidth))).rounded()))
 
         let bitmap = Bitmap.createBitmap(targetWidth, targetHeight, Bitmap.Config.ARGB_8888)
-        let didUsePixelCopy = await copyAndroidSnapshotWithPixelCopyIfAvailable(
-            into: bitmap,
-            minX: minX,
-            minY: minY,
-            maxX: maxX,
-            maxY: maxY,
-            afterScreenUpdates: config.afterScreenUpdates
-        )
-        if !didUsePixelCopy {
+        if config.androidCaptureMode == .webViewContent {
             drawAndroidSnapshot(
                 into: bitmap,
                 minX: minX,
@@ -1936,6 +1950,18 @@ extension WebCookie {
                 targetWidth: targetWidth,
                 targetHeight: targetHeight
             )
+        } else {
+            let didCopyVisibleWindowPixels = await copyAndroidVisibleWindowPixels(
+                into: bitmap,
+                minX: minX,
+                minY: minY,
+                maxX: maxX,
+                maxY: maxY
+            )
+            guard didCopyVisibleWindowPixels else {
+                bitmap.recycle()
+                throw WebSnapshotError.visibleWindowPixelsCaptureFailed
+            }
         }
 
         let outputStream = java.io.ByteArrayOutputStream()
@@ -1979,17 +2005,13 @@ extension WebCookie {
         webView.draw(canvas)
     }
 
-    private func copyAndroidSnapshotWithPixelCopyIfAvailable(
+    private func copyAndroidVisibleWindowPixels(
         into bitmap: Bitmap,
         minX: Int,
         minY: Int,
         maxX: Int,
-        maxY: Int,
-        afterScreenUpdates: Bool
+        maxY: Int
     ) async -> Bool {
-        guard afterScreenUpdates else {
-            return false
-        }
         guard android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O else {
             return false
         }

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -406,10 +406,23 @@ public final class WebViewNavigator: @unchecked Sendable {
     }
 
     @MainActor public func takeSnapshot(configuration: SkipWebSnapshotConfiguration? = nil) async throws -> SkipWebSnapshot {
+        let wrapperStartedAt = Date()
         guard let webEngine else {
             throw WebSnapshotError.emptySnapshot
         }
-        return try await webEngine.takeSnapshot(configuration: configuration)
+        let beforeEngineAt = Date()
+        let snapshot = try await webEngine.takeSnapshot(configuration: configuration)
+        let afterEngineAt = Date()
+        let dataAccessStartedAt = Date()
+        let snapshotByteCount = snapshot.imageData.count
+        let dataAccessFinishedAt = Date()
+        let beforeEngineElapsedMs = Int(beforeEngineAt.timeIntervalSince(wrapperStartedAt) * 1000)
+        let engineAwaitElapsedMs = Int(afterEngineAt.timeIntervalSince(beforeEngineAt) * 1000)
+        let totalElapsedMs = Int(afterEngineAt.timeIntervalSince(wrapperStartedAt) * 1000)
+        let wrapperDataAccessElapsedMs = Int(dataAccessFinishedAt.timeIntervalSince(dataAccessStartedAt) * 1000)
+        let returnReadyElapsedMs = Int(dataAccessFinishedAt.timeIntervalSince(wrapperStartedAt) * 1000)
+        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v4-wrapper-timing phase=webViewWrapper beforeEngineElapsedMs=\(beforeEngineElapsedMs) engineAwaitElapsedMs=\(engineAwaitElapsedMs) totalElapsedMs=\(totalElapsedMs) wrapperDataAccessElapsedMs=\(wrapperDataAccessElapsedMs) returnReadyElapsedMs=\(returnReadyElapsedMs) bytes=\(snapshotByteCount) format=\(snapshot.imageFormat.mimeType) quality=\(snapshot.imageFormat.quality)")
+        return snapshot
     }
 
     @MainActor public func cookies(for url: URL) async -> [WebCookie] {

--- a/Sources/SkipWeb/WebView.swift
+++ b/Sources/SkipWeb/WebView.swift
@@ -406,23 +406,10 @@ public final class WebViewNavigator: @unchecked Sendable {
     }
 
     @MainActor public func takeSnapshot(configuration: SkipWebSnapshotConfiguration? = nil) async throws -> SkipWebSnapshot {
-        let wrapperStartedAt = Date()
         guard let webEngine else {
             throw WebSnapshotError.emptySnapshot
         }
-        let beforeEngineAt = Date()
-        let snapshot = try await webEngine.takeSnapshot(configuration: configuration)
-        let afterEngineAt = Date()
-        let dataAccessStartedAt = Date()
-        let snapshotByteCount = snapshot.imageData.count
-        let dataAccessFinishedAt = Date()
-        let beforeEngineElapsedMs = Int(beforeEngineAt.timeIntervalSince(wrapperStartedAt) * 1000)
-        let engineAwaitElapsedMs = Int(afterEngineAt.timeIntervalSince(beforeEngineAt) * 1000)
-        let totalElapsedMs = Int(afterEngineAt.timeIntervalSince(wrapperStartedAt) * 1000)
-        let wrapperDataAccessElapsedMs = Int(dataAccessFinishedAt.timeIntervalSince(dataAccessStartedAt) * 1000)
-        let returnReadyElapsedMs = Int(dataAccessFinishedAt.timeIntervalSince(wrapperStartedAt) * 1000)
-        logger.info("[skip-web-snapshot-probe] marker=2026-06-12-local-snapshot-optimization-v4-wrapper-timing phase=webViewWrapper beforeEngineElapsedMs=\(beforeEngineElapsedMs) engineAwaitElapsedMs=\(engineAwaitElapsedMs) totalElapsedMs=\(totalElapsedMs) wrapperDataAccessElapsedMs=\(wrapperDataAccessElapsedMs) returnReadyElapsedMs=\(returnReadyElapsedMs) bytes=\(snapshotByteCount) format=\(snapshot.imageFormat.mimeType) quality=\(snapshot.imageFormat.quality)")
-        return snapshot
+        return try await webEngine.takeSnapshot(configuration: configuration)
     }
 
     @MainActor public func cookies(for url: URL) async -> [WebCookie] {

--- a/Tests/SkipWebTests/SkipWebTests.swift
+++ b/Tests/SkipWebTests/SkipWebTests.swift
@@ -492,14 +492,28 @@ final class SkipWebTests: XCTestCase {
         XCTAssertTrue(config.rect.isNull)
         XCTAssertNil(config.snapshotWidth)
         XCTAssertTrue(config.afterScreenUpdates)
+        XCTAssertEqual(config.imageFormat.mimeType, "image/jpeg")
+        XCTAssertEqual(config.imageFormat.quality, 0.85)
     }
 
     func testSnapshotConfigurationFieldRoundTrip() {
         let rect = SkipWebSnapshotRect(x: 10, y: 20, width: 120, height: 80)
-        let config = SkipWebSnapshotConfiguration(rect: rect, snapshotWidth: 64, afterScreenUpdates: false)
+        let config = SkipWebSnapshotConfiguration(rect: rect, snapshotWidth: 64, afterScreenUpdates: false, imageFormat: .png)
         XCTAssertEqual(config.rect, rect)
         XCTAssertEqual(config.snapshotWidth, 64)
         XCTAssertFalse(config.afterScreenUpdates)
+        XCTAssertEqual(config.imageFormat, .png)
+    }
+
+    func testSnapshotImageFormatJPEGQualityClamps() {
+        XCTAssertEqual(SkipWebSnapshotImageFormat.jpeg(quality: -1.0).quality, 0.0)
+        XCTAssertEqual(SkipWebSnapshotImageFormat.jpeg(quality: 2.0).quality, 1.0)
+        XCTAssertEqual(SkipWebSnapshotImageFormat.jpeg().mimeType, "image/jpeg")
+    }
+
+    func testSnapshotImageFormatPNG() {
+        XCTAssertEqual(SkipWebSnapshotImageFormat.png.mimeType, "image/png")
+        XCTAssertEqual(SkipWebSnapshotImageFormat.png.quality, 1.0)
     }
 
     @MainActor func testTakeSnapshotDefault() async throws {
@@ -529,7 +543,9 @@ final class SkipWebTests: XCTestCase {
             }
             throw error
         }
-        XCTAssertFalse(snapshot.pngData.isEmpty)
+        XCTAssertFalse(snapshot.imageData.isEmpty)
+        XCTAssertEqual(snapshot.imageFormat.mimeType, "image/jpeg")
+        XCTAssertEqual(snapshot.imageFormat.quality, 0.85)
         XCTAssertGreaterThan(snapshot.pixelWidth, 0)
         XCTAssertGreaterThan(snapshot.pixelHeight, 0)
         #endif
@@ -565,7 +581,8 @@ final class SkipWebTests: XCTestCase {
             }
             throw error
         }
-        XCTAssertFalse(snapshot.pngData.isEmpty)
+        XCTAssertFalse(snapshot.imageData.isEmpty)
+        XCTAssertEqual(snapshot.imageFormat.mimeType, "image/jpeg")
         XCTAssertGreaterThan(snapshot.pixelWidth, 0)
         XCTAssertGreaterThan(snapshot.pixelHeight, 0)
         XCTAssertGreaterThanOrEqual(snapshot.pixelWidth, Int(requestedWidth))
@@ -612,7 +629,7 @@ final class SkipWebTests: XCTestCase {
         let snapshot = try await snapshotEngine.takeSnapshot(
             configuration: SkipWebSnapshotConfiguration(afterScreenUpdates: false)
         )
-        XCTAssertFalse(snapshot.pngData.isEmpty)
+        XCTAssertFalse(snapshot.imageData.isEmpty)
         XCTAssertGreaterThan(snapshot.pixelWidth, 0)
         XCTAssertGreaterThan(snapshot.pixelHeight, 0)
         #endif

--- a/Tests/SkipWebTests/SkipWebTests.swift
+++ b/Tests/SkipWebTests/SkipWebTests.swift
@@ -492,16 +492,24 @@ final class SkipWebTests: XCTestCase {
         XCTAssertTrue(config.rect.isNull)
         XCTAssertNil(config.snapshotWidth)
         XCTAssertTrue(config.afterScreenUpdates)
+        XCTAssertEqual(config.androidCaptureMode, .webViewContent)
         XCTAssertEqual(config.imageFormat.mimeType, "image/jpeg")
         XCTAssertEqual(config.imageFormat.quality, 0.85)
     }
 
     func testSnapshotConfigurationFieldRoundTrip() {
         let rect = SkipWebSnapshotRect(x: 10, y: 20, width: 120, height: 80)
-        let config = SkipWebSnapshotConfiguration(rect: rect, snapshotWidth: 64, afterScreenUpdates: false, imageFormat: .png)
+        let config = SkipWebSnapshotConfiguration(
+            rect: rect,
+            snapshotWidth: 64,
+            afterScreenUpdates: false,
+            androidCaptureMode: .visibleWindowPixels,
+            imageFormat: .png
+        )
         XCTAssertEqual(config.rect, rect)
         XCTAssertEqual(config.snapshotWidth, 64)
         XCTAssertFalse(config.afterScreenUpdates)
+        XCTAssertEqual(config.androidCaptureMode, .visibleWindowPixels)
         XCTAssertEqual(config.imageFormat, .png)
     }
 


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Codex assisted with implementation, documentation, automated tests, generated-bridge inspection, and consumer app compile validation. The snapshot lab exposes the timing and Android capture-source controls for device comparison.

-----

## Summary

- Improves snapshot performance by making JPEG the default snapshot encoding (`.jpeg(quality: 0.85)`) instead of PNG.
- In local debug measurements this is typically around a **2x speedup** with **~85% smaller image data**.
- Removes Android's extra base64 encode/decode hop by wrapping encoded bytes directly with `Data(platformValue:)`.
- Adds an explicit Android capture-source API: `.webViewContent` uses `WebView.draw(Canvas)`, while `.visibleWindowPixels` uses `PixelCopy`.
- Separates capture timing from capture source: `afterScreenUpdates` controls only the optional UI-tick wait.

## Breaking Changes

- `SkipWebSnapshot.pngData` has been replaced with `SkipWebSnapshot.imageData`.
- Snapshot bytes are no longer guaranteed to be PNG. Callers should use `snapshot.imageFormat.mimeType` when deciding how to store, upload, or display the result.
- Code that still needs PNG output should request it explicitly with `imageFormat: .png`.
- Android no longer selects PixelCopy versus Canvas from `afterScreenUpdates`, and it does not automatically fall back between capture modes.

## API Shape

```swift
public struct SkipWebSnapshotImageFormat: Equatable, Sendable {
    public static let png: SkipWebSnapshotImageFormat
    public static func jpeg(quality: Double = 0.85) -> SkipWebSnapshotImageFormat

    public let mimeType: String
    public let quality: Double
}

public enum AndroidSnapshotCaptureMode: Hashable, Sendable {
    case webViewContent
    case visibleWindowPixels
}

public struct SkipWebSnapshotConfiguration: Sendable {
    public var afterScreenUpdates: Bool
    public var androidCaptureMode: AndroidSnapshotCaptureMode
    public var imageFormat: SkipWebSnapshotImageFormat
}

public struct SkipWebSnapshot: Sendable {
    public let imageData: Data
    public let imageFormat: SkipWebSnapshotImageFormat
}
```

`.webViewContent` is the default when `androidCaptureMode` is omitted.

## Android Capture Modes

| Mode | Captures |
| --- | --- |
| `.webViewContent` | The WebView's rendered content, using `WebView.draw(Canvas)`. The capture compensates for the current scroll offset and excludes other window content, including overlays and blur effects. Some video, surface, or other compositor-backed content may not appear. |
| `.visibleWindowPixels` | The final pixels currently composited inside the WebView's window rectangle, using `PixelCopy`. This includes WebView content and anything drawn over it, including overlays and blur effects. |

## Usage Example

```swift
let snapshot = try await navigator.takeSnapshot(
    configuration: SkipWebSnapshotConfiguration(
        snapshotWidth: 240,
        afterScreenUpdates: true,
        androidCaptureMode: .webViewContent,
        imageFormat: .jpeg(quality: 0.85)
    )
)

let bytes = snapshot.imageData
let mimeType = snapshot.imageFormat.mimeType
```

For PNG compatibility:

```swift
let snapshot = try await navigator.takeSnapshot(
    configuration: SkipWebSnapshotConfiguration(imageFormat: .png)
)
```

## Testing

- `swift test`
- Kotlin/JUnit: 86 tests, 68 passed, 18 skipped, 0 failed
- Android consumer-app compile validation
- Generated Kotlin and Swift bridge projections inspected for the new enum and configuration field

## Risks / Limitations

- `.webViewContent` may omit some video, surface, or other compositor-backed content.
- `.visibleWindowPixels` requires the WebView to be attached to a valid window and includes anything composited over its rectangle.
- PixelCopy failure throws `WebSnapshotError.visibleWindowPixelsCaptureFailed`; SkipWeb does not automatically fall back between capture modes.
